### PR TITLE
Handle missing changelog file

### DIFF
--- a/src/actions/changelogs.ts
+++ b/src/actions/changelogs.ts
@@ -6,6 +6,14 @@ import path from "path";
 const CHANGELOG_PATH = path.join(process.cwd(), "changelog.json");
 
 export async function readChangelogs() {
-    const content = await fs.readFile(CHANGELOG_PATH, "utf-8");
-    return JSON.parse(content);
+    try {
+        const content = await fs.readFile(CHANGELOG_PATH, "utf-8");
+        return JSON.parse(content);
+    } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+            return [];
+        }
+
+        throw error;
+    }
 }


### PR DESCRIPTION
Makes homepage changelog loading tolerant of a missing runtime `changelog.json` file, returning an empty changelog list instead of crashing the app.

For the VPS compose file, the real changelog should still be mounted with:

```yaml
volumes:
  - ./mapsets:/app/mapsets
  - ./changelog.json:/app/changelog.json:ro
  - ./tmp:/app/tmp
```