### PR TITLE
Tighten UI density and motion polish

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,6 @@
         "clsx": "^2.1.1",
         "dotenv-cli": "^10.0.0",
         "fluent-ffmpeg": "^2.1.2",
-        "framer-motion": "^12.5.0",
         "lucide-react": "^0.539.0",
         "next": "^16.0.8",
         "next-auth": "^5.0.0-beta.25",
@@ -708,8 +707,6 @@
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
-    "framer-motion": ["framer-motion@12.23.12", "", { "dependencies": { "motion-dom": "^12.23.12", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg=="],
-
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
@@ -933,10 +930,6 @@
     "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
-
-    "motion-dom": ["motion-dom@12.23.12", "", { "dependencies": { "motion-utils": "^12.23.6" } }, "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw=="],
-
-    "motion-utils": ["motion-utils@12.23.6", "", {}, "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
         "clsx": "^2.1.1",
         "dotenv-cli": "^10.0.0",
         "fluent-ffmpeg": "^2.1.2",
-        "framer-motion": "^12.5.0",
         "lucide-react": "^0.539.0",
         "next": "^16.0.8",
         "next-auth": "^5.0.0-beta.25",

--- a/src/actions/announcements.ts
+++ b/src/actions/announcements.ts
@@ -18,6 +18,24 @@ export async function listAnnouncements(): Promise<Announcement[]> {
     }
 }
 
+export async function listRecentAnnouncements(limit: number = 6): Promise<Announcement[]> {
+    try {
+        const results = await query<Announcement>(
+            `
+            SELECT id, title, content, created_at
+            FROM announcements
+            ORDER BY created_at DESC
+            LIMIT ?
+        `,
+            [limit]
+        );
+        return (results as Announcement[]).map((r) => ({ ...r, created_at: new Date(r.created_at).toISOString() } as unknown as Announcement));
+    } catch (error) {
+        console.error("Error listing recent announcements:", error);
+        return [];
+    }
+}
+
 export async function getLatestAnnouncement(): Promise<Announcement | null> {
     try {
         const results = await query<Announcement>(`

--- a/src/app/HomeContent.tsx
+++ b/src/app/HomeContent.tsx
@@ -3,9 +3,7 @@
 import { StatsCard } from "./components/StatsCard";
 import { Gamepad2, Trophy, Users2 } from "lucide-react";
 import { useTranslationsContext } from "@/context/translations-provider";
-import { SupportersSection } from "./components/Supporters";
 import Link from "next/link";
-import { ChangelogsSection } from "./components/Changelogs";
 
 interface ChangelogEntry {
     description: string;
@@ -30,27 +28,31 @@ interface HomeContentProps {
     announcementsHistory?: Array<{ id: number; title: string; content: string; created_at: string }>;
 }
 
-export default function HomeContent({ changelogs, highStats, latestAnnouncement, announcementsHistory }: HomeContentProps) {
+export function HomeStatsSection({ highStats }: Pick<HomeContentProps, "highStats">) {
     const { t } = useTranslationsContext();
 
     return (
-        <>
-            <section className="py-16 bg-secondary/20">
-                <div className="container mx-auto px-4">
-                    <h2 className="text-2xl font-bold mb-6 text-center">{t.home.statistics.title}</h2>
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <section className="border-y border-border/40 bg-secondary/20 py-12">
+            <div className="container mx-auto px-4">
+                <h2 className="text-2xl font-bold mb-6 text-center">{t.home.statistics.title}</h2>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:gap-5">
+                    <div className="motion-fade-up">
                         <StatsCard
                             title={t.home.statistics.totalPlayers.title}
                             value={highStats.total_users.toLocaleString()}
                             description={t.home.statistics.totalPlayers.description}
                             icon={<Users2 className="h-6 w-6" />}
                         />
+                    </div>
+                    <div className="motion-fade-up motion-delay-1">
                         <StatsCard
                             title={t.home.statistics.gamesPlayed.title}
                             value={highStats.total_games.toLocaleString()}
                             description={t.home.statistics.gamesPlayed.description}
                             icon={<Gamepad2 className="h-6 w-6" />}
                         />
+                    </div>
+                    <div className="motion-fade-up motion-delay-2">
                         <StatsCard
                             title={t.home.statistics.highScore.title}
                             value={highStats.highest_points.toLocaleString()}
@@ -59,54 +61,62 @@ export default function HomeContent({ changelogs, highStats, latestAnnouncement,
                         />
                     </div>
                 </div>
-            </section>
+            </div>
+        </section>
+    );
+}
 
-            {latestAnnouncement && (
-                <section className="py-16">
-                    <div className="container mx-auto px-4">
-                        <h2 className="text-2xl font-bold mb-6 text-center">{t.home.announcements.title}</h2>
+export function HomeAnnouncementsSection({ latestAnnouncement, announcementsHistory }: Pick<HomeContentProps, "latestAnnouncement" | "announcementsHistory">) {
+    const { t } = useTranslationsContext();
 
-                        <div className="max-w-3xl mx-auto">
-                            <Link href="/announcements" className="block">
-                                <div className="p-6 rounded-lg bg-card border border-border shadow-sm">
-                                    <div className="flex items-center gap-2 mb-3">
-                                        <div className="w-2 h-2 bg-primary rounded-full"></div>
-                                        <span className="text-sm font-medium text-primary">{t.home.announcements.latestLabel}</span>
-                                    </div>
-                                    <h3 className="text-xl font-semibold mb-2">{latestAnnouncement.title}</h3>
-                                    <div className="text-sm text-muted-foreground mb-3">{new Date(latestAnnouncement.created_at).toLocaleString()}</div>
-                                    <div className="whitespace-pre-wrap text-foreground">{latestAnnouncement.content}</div>
-                                </div>
-                                {announcementsHistory && announcementsHistory.length > 1 && (
-                                    <div className="mt-6 p-4 rounded-lg bg-muted/50">
-                                        <div className="text-sm text-muted-foreground">
-                                            <strong>{t.home.announcements.previous}</strong>
-                                            <ul className="mt-2 space-y-1">
-                                                {announcementsHistory.slice(1, 6).map((a) => (
-                                                    <li key={a.id}>
-                                                        <span className="font-medium">{a.title}</span> <span className="text-xs text-muted-foreground">— {new Date(a.created_at).toLocaleDateString()}</span>
-                                                    </li>
-                                                ))}
-                                            </ul>
-                                        </div>
-                                    </div>
-                                )}
-                                <div className="mt-4 text-center">
-                                    <span className="text-sm text-primary hover:text-primary/80 underline">{t.home.announcements.viewAll} →</span>
-                                </div>
-                            </Link>
+    if (!latestAnnouncement) return null;
+
+    return (
+        <section className="py-12">
+            <div className="container mx-auto px-4">
+                <h2 className="text-2xl font-bold mb-6 text-center">{t.home.announcements.title}</h2>
+
+                <div className="mx-auto max-w-2xl">
+                    <Link href="/announcements" className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-lg">
+                        <div className="interactive-surface rounded-lg border border-border/70 bg-card p-4 shadow-sm group-hover:border-primary/40 sm:p-5">
+                            <div className="flex items-center gap-2 mb-3">
+                                <div className="soft-loading-dot w-2 h-2 bg-primary rounded-full"></div>
+                                <span className="text-sm font-medium text-primary">{t.home.announcements.latestLabel}</span>
+                            </div>
+                            <h3 className="text-xl font-semibold mb-2">{latestAnnouncement.title}</h3>
+                            <div className="text-sm text-muted-foreground mb-3">{new Date(latestAnnouncement.created_at).toLocaleString()}</div>
+                            <div className="whitespace-pre-wrap text-foreground">{latestAnnouncement.content}</div>
                         </div>
-                    </div>
-                </section>
-            )}
+                        {announcementsHistory && announcementsHistory.length > 1 && (
+                            <div className="motion-scale-in mt-4 rounded-lg border border-border/50 bg-muted/50 p-4">
+                                <div className="text-sm text-muted-foreground">
+                                    <strong>{t.home.announcements.previous}</strong>
+                                    <ul className="mt-2 space-y-1">
+                                        {announcementsHistory.slice(1, 6).map((a) => (
+                                            <li key={a.id}>
+                                                <span className="font-medium">{a.title}</span> <span className="text-xs text-muted-foreground">— {new Date(a.created_at).toLocaleDateString()}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            </div>
+                        )}
+                        <div className="mt-4 text-center">
+                            <span className="text-sm text-primary hover:text-primary/80 underline">{t.home.announcements.viewAll} →</span>
+                        </div>
+                    </Link>
+                </div>
+            </div>
+        </section>
+    );
+}
 
-            <section className="py-16 bg-secondary/20">
-                <SupportersSection />
-            </section>
+export default function HomeContent({ highStats, latestAnnouncement, announcementsHistory }: HomeContentProps) {
+    return (
+        <>
+            <HomeStatsSection highStats={highStats} />
 
-            <section className="py-16">
-                <ChangelogsSection changelogs={changelogs} />
-            </section>
+            <HomeAnnouncementsSection latestAnnouncement={latestAnnouncement} announcementsHistory={announcementsHistory} />
         </>
     );
 }

--- a/src/app/about/client.tsx
+++ b/src/app/about/client.tsx
@@ -26,32 +26,32 @@ export default function AboutClient() {
     const { t } = useTranslationsContext();
 
     return (
-        <div className="container mx-auto px-4 py-16 max-w-4xl">
-            <h1 className="text-4xl font-bold mb-8 text-center">{t.about.title}</h1>
+        <div className="container mx-auto px-4 py-10 md:py-16 max-w-4xl">
+            <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">{t.about.title}</h1>
 
             <div className="space-y-8">
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.about.whatIs.title}</h2>
                     <p className="text-foreground/80 leading-relaxed mb-4">{t.about.whatIs.description1}</p>
                     <p className="text-foreground/80 leading-relaxed">{t.about.whatIs.description2}</p>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-6">{t.about.gameModes.title}</h2>
                     <div className="grid gap-6 md:grid-cols-2">
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.gameModes.background.title}</h3>
                             <p className="text-foreground/80">{t.about.gameModes.background.description}</p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.gameModes.audio.title}</h3>
                             <p className="text-foreground/80">{t.about.gameModes.audio.description}</p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.gameModes.skin.title}</h3>
                             <p className="text-foreground/80">{t.about.gameModes.skin.description}</p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">
                                 {t.about.gameModes.more.title}
                                 <span className="text-xs bg-primary/20 px-2 py-1 rounded ml-2">{t.about.gameModes.more.planned}</span>
@@ -61,7 +61,7 @@ export default function AboutClient() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.about.howToPlay.title}</h2>
                     <div className="space-y-4">
                         <div className="flex items-start gap-4">
@@ -88,15 +88,15 @@ export default function AboutClient() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.about.scoringSystem.title}</h2>
                     <div className="grid gap-4 md:grid-cols-2">
-                        <div className="bg-background/50 p-4 rounded-lg">
+                        <div className="bg-background/50 p-4 rounded-lg border border-border/50">
                             <p className="text-foreground/80">{t.about.scoringSystem.points.base.replace("{points}", BASE_POINTS.toString())}</p>
                             <p className="text-foreground/80">{t.about.scoringSystem.points.timeBonus.replace("{multiplier}", TIME_BONUS_MULTIPLIER.toString())}</p>
                             <p className="text-foreground/80">{t.about.scoringSystem.points.streakBonus.replace("{bonus}", STREAK_BONUS.toString())}</p>
                         </div>
-                        <div className="bg-background/50 p-4 rounded-lg">
+                        <div className="bg-background/50 p-4 rounded-lg border border-border/50">
                             <p className="text-foreground/80">{t.about.scoringSystem.gameInfo.length.replace("{rounds}", MAX_ROUNDS.toString())}</p>
                             <p className="text-foreground/80">{t.about.scoringSystem.gameInfo.time.replace("{seconds}", ROUND_TIME.toString())}</p>
                             <p className="text-foreground/80">{t.about.scoringSystem.points.skipPenalty.replace("{penalty}", SKIP_PENALTY.toString())}</p>
@@ -104,32 +104,32 @@ export default function AboutClient() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-6">{t.about.features.title}</h2>
                     <div className="grid gap-6 md:grid-cols-2">
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.features.leaderboards.title}</h3>
                             <p className="text-foreground/80">{t.about.features.leaderboards.description}</p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.features.autoComplete.title}</h3>
                             <p className="text-foreground/80">{t.about.features.autoComplete.description}</p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.features.profiles.title}</h3>
                             <p className="text-foreground/80">{t.about.features.profiles.description}</p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.features.api.title}</h3>
                             <p className="text-foreground/80">{t.about.features.api.description}</p>
                         </div>
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-6">{t.about.documentation.title}</h2>
                     <div className="grid gap-6 md:grid-cols-2">
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.documentation.api.title}</h3>
                             <p className="text-foreground/80 mb-4">{t.about.documentation.api.description}</p>
                             <a
@@ -141,7 +141,7 @@ export default function AboutClient() {
                                 {t.common.viewMore} →
                             </a>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.documentation.technical.title}</h3>
                             <p className="text-foreground/80 mb-4">{t.about.documentation.technical.description}</p>
                             <a
@@ -156,10 +156,10 @@ export default function AboutClient() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-6">{t.about.credits.title}</h2>
                     <div className="grid gap-6 md:grid-cols-2">
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.credits.development.title}</h3>
                             <p className="text-foreground/80">
                                 {t.about.credits.development.description.split("{author}").map((part, index, array) => (
@@ -170,11 +170,11 @@ export default function AboutClient() {
                                 ))}
                             </p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.credits.artwork.title}</h3>
                             <p className="text-foreground/80">{t.home.hero.artCredit}</p>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.credits.inspiration.title}</h3>
                             <div className="space-y-2">
                                 <p className="text-foreground/80">
@@ -195,7 +195,7 @@ export default function AboutClient() {
                                 </p>
                             </div>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.credits.specialThanks.title}</h3>
                             <div className="space-y-2">
                                 <p className="text-foreground/80">{t.about.credits.specialThanks.items.peppy}</p>
@@ -206,10 +206,10 @@ export default function AboutClient() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-6">{t.about.contact.title}</h2>
                     <div className="grid gap-6 md:grid-cols-2">
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.contact.getInTouch.title}</h3>
                             <div className="space-y-2">
                                 <p className="text-foreground/80">
@@ -229,7 +229,7 @@ export default function AboutClient() {
                                 </p>
                             </div>
                         </div>
-                        <div className="bg-background/50 p-6 rounded-lg">
+                        <div className="bg-background/50 p-5 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.contact.contribute.title}</h3>
                             <p className="text-foreground/80 mb-4">{t.about.contact.contribute.description}</p>
                             <div className="space-y-2">

--- a/src/app/admin/beatmaps/ui.tsx
+++ b/src/app/admin/beatmaps/ui.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 import { listMapsets, removeMapset, fetchBackgroundImage, Mapset } from "../actions/mapsets";
 
@@ -108,9 +109,9 @@ export default function BeatmapsAdmin() {
     const nextPage = () => setPage((p) => p + 1);
 
     return (
-        <div className="space-y-6 p-6">
-            <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
+        <div className="space-y-6 p-4 sm:p-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex flex-wrap items-center gap-4">
                     <Link href="/admin">
                         <Button variant="ghost" size="sm">
                             Back
@@ -119,11 +120,11 @@ export default function BeatmapsAdmin() {
                     <h1 className="text-2xl font-bold">Beatmaps</h1>
                 </div>
 
-                <div className="text-sm text-muted-foreground">{output}</div>
+                <div className="text-sm text-muted-foreground break-words lg:text-right">{output}</div>
             </div>
 
-            <div className="flex items-center gap-4">
-                <input className="input" placeholder="Search artist or title" value={search} onChange={(e) => setSearch(e.target.value)} />
+            <div className="flex flex-col gap-3 rounded-lg border border-border/60 bg-card p-4 sm:flex-row sm:flex-wrap sm:items-center">
+                <Input className="sm:max-w-xs" placeholder="Search artist or title" value={search} onChange={(e) => setSearch(e.target.value)} />
                 <Button size="sm" onClick={() => fetchMapsets(1, search)}>
                     Search
                 </Button>
@@ -135,14 +136,14 @@ export default function BeatmapsAdmin() {
                 </Button>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
                 {mapsets.map((m) => (
-                    <div key={m.mapset_id} className="bg-card rounded-lg border border-border p-4 flex flex-col">
-                        <div className="flex items-center gap-4">
+                    <div key={m.mapset_id} className="bg-card rounded-lg border border-border/60 p-4 flex flex-col">
+                        <div className="flex items-start gap-4">
                             <div>
                                 <input type="checkbox" checked={!!selected[m.mapset_id]} onChange={() => handleToggle(m.mapset_id)} />
                             </div>
-                            <div className="w-28 h-16 relative rounded overflow-hidden bg-muted">
+                            <div className="w-28 h-16 relative rounded overflow-hidden bg-muted shrink-0">
                                 {images[m.mapset_id] ? (
                                     // eslint-disable-next-line @next/next/no-img-element
                                     <img src={images[m.mapset_id] as string} alt={m.title} className="w-full h-full object-cover" />
@@ -153,7 +154,7 @@ export default function BeatmapsAdmin() {
                                 )}
                             </div>
 
-                            <div className="flex-1">
+                            <div className="flex-1 min-w-0">
                                 <div className="font-semibold">{m.title}</div>
                                 <div className="text-sm text-muted-foreground">
                                     {m.artist} — {m.mapper}
@@ -162,12 +163,14 @@ export default function BeatmapsAdmin() {
                             </div>
                         </div>
 
-                        <div className="mt-4 flex gap-2">
+                        <div className="mt-4 flex flex-col gap-2 sm:flex-row">
                             <Button variant="destructive" size="sm" onClick={() => handleDelete(m.mapset_id)}>
                                 Delete
                             </Button>
-                            <a className="btn" href={`https://osu.ppy.sh/beatmapsets/${m.mapset_id}`} target="_blank" rel="noreferrer">
-                                <Button size="sm">Open osu!</Button>
+                            <a href={`https://osu.ppy.sh/beatmapsets/${m.mapset_id}`} target="_blank" rel="noreferrer" className="sm:w-auto">
+                                <Button size="sm" className="w-full sm:w-auto">
+                                    Open osu!
+                                </Button>
                             </a>
                         </div>
                     </div>

--- a/src/app/admin/menu.tsx
+++ b/src/app/admin/menu.tsx
@@ -524,7 +524,7 @@ export default function AdminMenu() {
     };
 
     return (
-        <div className="container mx-auto px-4 py-8 space-y-4">
+        <div className="container mx-auto px-4 py-6 md:py-8 space-y-4">
             <div className="flex justify-between items-center mb-8">
                 <h1 className="text-3xl font-bold">Admin Panel</h1>
                 <div>
@@ -536,7 +536,7 @@ export default function AdminMenu() {
 
             <CollapsibleSection title="Mapset Management">
                 <div className="space-y-8">
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Single Mapset</h3>
                         <div className="flex gap-4">
                             <Input type="number" placeholder="Mapset ID" value={mapsetId} onChange={(e) => setMapsetId(e.target.value)} />
@@ -552,7 +552,7 @@ export default function AdminMenu() {
                         </div>
                     </div>
 
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Bulk Upload Mapsets</h3>
                         <div className="space-y-4">
                             <div className="flex items-center gap-4">
@@ -571,7 +571,7 @@ export default function AdminMenu() {
 
             <CollapsibleSection title="Skins Management">
                 <div className="space-y-4">
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Random Skin</h3>
                         <div className="flex gap-4">
                             <Button onClick={handleListSkins} disabled={isLoading} variant="outline">
@@ -580,7 +580,7 @@ export default function AdminMenu() {
                         </div>
                     </div>
 
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Add Skin by ID or List</h3>
                         <div className="space-y-4">
                             <div className="flex gap-4">
@@ -603,7 +603,7 @@ export default function AdminMenu() {
                         </div>
                     </div>
 
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Remove Skin</h3>
                         <div className="flex gap-4">
                             <Input placeholder="Skin ID" value={skinRemoveId} onChange={(e) => setSkinRemoveId(e.target.value)} />
@@ -617,7 +617,7 @@ export default function AdminMenu() {
 
             <CollapsibleSection title="Badge Management">
                 <div className="space-y-8">
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Assign User Badges</h3>
                         <div className="space-y-4">
                             <div className="grid grid-cols-2 gap-4">
@@ -653,7 +653,7 @@ export default function AdminMenu() {
                         </div>
                     </div>
 
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Manage Badge Types</h3>
                         <div className="space-y-4">
                             <div className="grid grid-cols-2 gap-4">
@@ -686,7 +686,7 @@ export default function AdminMenu() {
             </CollapsibleSection>
 
             <CollapsibleSection title="User">
-                <div className="bg-secondary/20 p-6 rounded-xl">
+                <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                     <Button onClick={handleSyncUsers} disabled={isLoading}>
                         Sync User Achievements
                     </Button>
@@ -694,7 +694,7 @@ export default function AdminMenu() {
             </CollapsibleSection>
 
             <CollapsibleSection title="Translation Management">
-                <div className="bg-secondary/20 p-6 rounded-xl">
+                <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                     <div className="space-y-4">
                         <div className="flex items-center space-x-4">
                             <div className="flex items-center space-x-2">
@@ -731,7 +731,7 @@ export default function AdminMenu() {
 
             <CollapsibleSection title="Report Management">
                 <div className="space-y-4">
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">View and Manage Reports</h3>
                         <Button
                             onClick={async () => {
@@ -758,7 +758,7 @@ export default function AdminMenu() {
                             List Reports
                         </Button>
                     </div>
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Update Report Status</h3>
                         <div className="flex gap-4">
                             <Input type="number" placeholder="Report ID" onChange={(e) => setReportId(e.target.value)} className="w-1/4" />
@@ -791,7 +791,7 @@ export default function AdminMenu() {
 
             <CollapsibleSection title="Announcements">
                 <div className="space-y-4">
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Create Announcement</h3>
                         <div className="space-y-4">
                             <Input placeholder="Title" value={announcementTitle} onChange={(e) => setAnnouncementTitle(e.target.value)} />
@@ -813,7 +813,7 @@ export default function AdminMenu() {
                         </div>
                     </div>
 
-                    <div className="bg-secondary/20 p-6 rounded-xl">
+                    <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                         <h3 className="text-lg font-medium mb-4">Existing Announcements</h3>
                         <div className="space-y-2">
                             {announcementsList.length === 0 ? (
@@ -839,7 +839,7 @@ export default function AdminMenu() {
             </CollapsibleSection>
 
             <CollapsibleSection title="Server Lockdown">
-                <div className="bg-secondary/20 p-6 rounded-xl">
+                <div className="bg-secondary/20 p-5 rounded-lg border border-border/50">
                     <h3 className="text-lg font-medium mb-4">Temporarily lock the server</h3>
                     <div className="flex items-center gap-4">
                         <Input type="number" className="w-24" value={String(lockMinutes)} onChange={(e) => setLockMinutes(Number(e.target.value))} />
@@ -857,7 +857,7 @@ export default function AdminMenu() {
                 </div>
             </CollapsibleSection>
 
-            <div className="bg-card p-6 rounded-lg border border-border" ref={consoleDivRef}>
+            <div className="bg-card p-5 sm:p-6 rounded-lg border border-border/60" ref={consoleDivRef}>
                 <h2 className="text-xl font-semibold mb-4">Console Output</h2>
                 <pre className="bg-background p-4 rounded-md h-64 overflow-y-auto whitespace-pre-wrap">{output}</pre>
                 <Button onClick={() => setOutput("")} variant="outline" className="mt-2">

--- a/src/app/admin/ui.tsx
+++ b/src/app/admin/ui.tsx
@@ -6,9 +6,9 @@ interface CollapsibleSectionProps {
 
 export function CollapsibleSection({ title, children, defaultOpen = false }: CollapsibleSectionProps) {
     return (
-        <details className="bg-card rounded-lg border border-border" open={defaultOpen}>
-            <summary className="text-xl font-semibold p-6 cursor-pointer hover:bg-secondary/10 transition-colors">{title}</summary>
-            <div className="p-6 pt-0 space-y-4">{children}</div>
+        <details className="bg-card rounded-lg border border-border/60" open={defaultOpen}>
+            <summary className="text-lg sm:text-xl font-semibold p-5 sm:p-6 cursor-pointer hover:bg-secondary/10 transition-colors">{title}</summary>
+            <div className="p-5 sm:p-6 pt-0 space-y-4">{children}</div>
         </details>
     );
 }

--- a/src/app/announcements/page.tsx
+++ b/src/app/announcements/page.tsx
@@ -7,19 +7,21 @@ export default async function AnnouncementsPage() {
     const announcements = await listAnnouncements();
 
     return (
-        <div className="min-h-screen bg-background text-foreground py-12">
-            <div className="container mx-auto px-4">
-                <h1 className="text-2xl font-bold mb-6">Announcements</h1>
+        <div className="bg-background text-foreground py-10 md:py-16">
+            <div className="container mx-auto px-4 max-w-3xl">
+                <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">Announcements</h1>
                 {announcements.length === 0 ? (
-                    <p className="text-muted-foreground">No announcements</p>
+                    <div className="rounded-lg border border-border/60 bg-card p-8 text-center text-muted-foreground">No announcements</div>
                 ) : (
-                    <div className="space-y-4">
+                    <div className="space-y-5">
                         {announcements.map((a) => (
-                            <div key={a.id} className="p-4 bg-card border border-border rounded-md">
-                                <h2 className="text-lg font-semibold">{a.title}</h2>
-                                <div className="text-xs text-muted-foreground mb-2">{new Date(a.created_at).toLocaleString()}</div>
-                                <div className="whitespace-pre-wrap">{a.content}</div>
-                            </div>
+                            <article key={a.id} className="p-5 sm:p-6 bg-card border border-border/60 rounded-lg">
+                                <h2 className="text-xl font-semibold">{a.title}</h2>
+                                <time className="block text-sm text-muted-foreground mb-4" dateTime={new Date(a.created_at).toISOString()}>
+                                    {new Date(a.created_at).toLocaleString()}
+                                </time>
+                                <div className="whitespace-pre-wrap leading-relaxed text-foreground/85">{a.content}</div>
+                            </article>
                         ))}
                     </div>
                 )}

--- a/src/app/components/Changelogs.tsx
+++ b/src/app/components/Changelogs.tsx
@@ -1,4 +1,5 @@
-import { motion } from "framer-motion";
+"use client";
+
 import { useTranslationsContext } from "@/context/translations-provider";
 import { Changelog } from "../HomeContent";
 
@@ -10,90 +11,53 @@ export function ChangelogsSection({ changelogs }: ChangelogsProps) {
     const { t } = useTranslationsContext();
     const sortedChangelogs = [...changelogs].reverse();
 
-    const containerVariants = {
-        hidden: { opacity: 0 },
-        visible: {
-            opacity: 1,
-            transition: {
-                duration: 0.4,
-                when: "beforeChildren",
-                staggerChildren: 0.05,
-            },
-        },
-    };
-
-    const changelogVariants = {
-        hidden: {
-            opacity: 0,
-            y: 5, 
-        },
-        visible: {
-            opacity: 1,
-            y: 0,
-            transition: {
-                duration: 0.2,
-            },
-        },
-    };
-
     return (
         <div className="container mx-auto px-4">
-            <motion.div
-                className="bg-card rounded-xl p-6 border border-border/50"
-                initial="hidden"
-                animate="visible"
-                variants={containerVariants}
-            >
-                <motion.h2 className="text-2xl font-bold mb-6 text-center" variants={changelogVariants}>
-                    {t.home.updates.title}
-                </motion.h2>
+            <div className="rounded-lg border border-border/60 bg-card p-4 sm:p-5">
+                <h2 className="mb-5 text-center text-2xl font-bold">{t.home.updates.title}</h2>
 
-                <div className="space-y-6 max-h-[500px] overflow-y-auto scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent">
+                <div className="max-h-[420px] space-y-5 overflow-y-auto scrollbar-thin scrollbar-thumb-primary/20 scrollbar-track-transparent">
                     {sortedChangelogs.map((log, i) => (
-                        <motion.div key={i} className="border-b border-border/50 last:border-0 pb-6 last:pb-0" variants={changelogVariants}>
-                            <div className="flex items-center gap-2 mb-3">
+                        <div key={i} className="border-b border-border/50 pb-5 last:border-0 last:pb-0">
+                            <div className="mb-3 flex items-center gap-2">
                                 <span className="text-lg font-semibold">{log.version}</span>
                                 <span className="text-sm text-foreground/70">• {log.date}</span>
                             </div>
 
                             <ul className="space-y-2">
                                 {log.changes.map((change, j) => (
-                                    <motion.li key={j} className="text-foreground/80 flex items-start gap-2" variants={changelogVariants}>
+                                    <li key={j} className="text-foreground/80 flex items-start gap-2">
                                         <span className="text-primary">•</span>
                                         <span>{change.description}</span>
                                         <div className="space-x-2 text-sm">
                                             {change.commit && (
-                                                <motion.a
+                                                <a
                                                     href={`https://github.com/yorunoken/osu-guessr/commit/${change.commit}`}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                     className="text-primary hover:underline inline-block"
-                                                    whileHover={{ scale: 1.05 }}
-                                                    transition={{ duration: 0.2 }}
                                                 >
                                                     [commit]
-                                                </motion.a>
+                                                </a>
                                             )}
                                             {change.pr && (
-                                                <motion.a
+                                                <a
                                                     href={`https://github.com/yorunoken/osu-guessr/pull/${change.pr}`}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                     className="text-primary hover:underline inline-block"
-                                                    whileHover={{ scale: 1.05 }}
-                                                    transition={{ duration: 0.2 }}
                                                 >
                                                     [PR #{change.pr}]
-                                                </motion.a>
+                                                </a>
                                             )}
                                         </div>
-                                    </motion.li>
+                                    </li>
                                 ))}
                             </ul>
-                        </motion.div>
+                        </div>
                     ))}
                 </div>
-            </motion.div>
+            </div>
         </div>
     );
 }

--- a/src/app/components/GameModeCards.tsx
+++ b/src/app/components/GameModeCards.tsx
@@ -1,7 +1,6 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
-import { motion } from "framer-motion";
 import { useTranslationsContext } from "@/context/translations-provider";
 import { gameRegistry } from "@/lib/game/registry";
 
@@ -9,67 +8,27 @@ export default function GameModeCards() {
     const { t } = useTranslationsContext();
     const gameModes = gameRegistry.getAllModes();
 
-    const containerVariants = {
-        hidden: { opacity: 0 },
-        visible: {
-            opacity: 1,
-            transition: {
-                staggerChildren: 0.15,
-            },
-        },
-    };
-
-    const cardVariants = {
-        hidden: {
-            opacity: 0,
-            y: 20,
-        },
-        visible: {
-            opacity: 1,
-            y: 0,
-            transition: {
-                duration: 0.5,
-            },
-        },
-    } as const;
-
     return (
-        <section className="py-24 bg-background" id="gamemodes">
+        <section className="py-14 md:py-16 bg-background" id="gamemodes">
             <div className="container mx-auto px-4">
-                <motion.h2
-                    initial={{ opacity: 0, y: 10 }}
-                    whileInView={{ opacity: 1, y: 0 }}
-                    viewport={{ once: true }}
-                    transition={{ duration: 0.4 }}
-                    className="text-4xl font-bold text-center mb-16 text-foreground"
-                >
-                    {t.gameModes.title}
-                </motion.h2>
+                <h2 className="mb-8 text-center text-3xl font-bold text-foreground md:mb-10">{t.gameModes.title}</h2>
 
-                <motion.div variants={containerVariants} initial="hidden" whileInView="visible" viewport={{ once: true }} className="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3 lg:gap-5">
                     {gameModes.map((mode, index) => (
-                        <motion.div key={index} variants={cardVariants} viewport={{ once: true }} whileHover={{ y: -5 }} transition={{ duration: 0.2 }}>
-                            <Link href={mode.url} className="block">
-                                <div className="relative h-80 rounded-xl overflow-hidden bg-card border border-border/50 transition-all duration-300">
-                                    <motion.div whileHover={{ scale: 1.03 }} transition={{ duration: 0.6 }} viewport={{ once: true }}>
-                                        <Image src={mode.image || "/placeholder.svg"} alt={t.gameModes.modes[mode.id].title} layout="fill" objectFit="cover" className="opacity-60 transition-all duration-300" />
-                                    </motion.div>
-                                    <div className="absolute inset-0 bg-gradient-to-t from-card to-transparent"></div>
-                                    <motion.div
-                                        className="absolute inset-0 flex flex-col justify-end p-8"
-                                        initial={{ opacity: 0, y: 10 }}
-                                        whileInView={{ opacity: 1, y: 0 }}
-                                        viewport={{ once: true }}
-                                        transition={{ delay: 0.2, duration: 0.4 }}
-                                    >
-                                        <h3 className="text-2xl font-bold mb-3 text-primary">{t.gameModes.modes[mode.id].title}</h3>
+                        <div key={mode.id} className={`motion-fade-up ${index === 1 ? "motion-delay-1" : index === 2 ? "motion-delay-2" : ""}`}>
+                            <Link href={mode.url} className="group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-lg">
+                                <div className="interactive-surface relative h-64 overflow-hidden rounded-lg border border-border/60 bg-card group-hover:border-primary/40 sm:h-72 md:h-64 lg:h-72">
+                                    <Image src={mode.image || "/placeholder.svg"} alt={t.gameModes.modes[mode.id].title} fill sizes="(min-width: 768px) 33vw, 100vw" className="object-cover opacity-65 transition-[transform,opacity,filter] duration-500 ease-[var(--ease-out-smooth)] group-hover:scale-[1.035] group-hover:opacity-75" />
+                                    <div className="absolute inset-0 bg-gradient-to-t from-background via-background/55 to-transparent transition-opacity duration-300 ease-[var(--ease-out-smooth)] group-hover:opacity-90"></div>
+                                    <div className="absolute inset-0 flex flex-col justify-end p-5 sm:p-6">
+                                        <h3 className="mb-2 text-xl font-bold text-primary transition-colors duration-200 group-hover:text-primary/90 lg:text-2xl">{t.gameModes.modes[mode.id].title}</h3>
                                         <p className="text-foreground/70 text-sm leading-relaxed">{t.gameModes.modes[mode.id].description}</p>
-                                    </motion.div>
+                                    </div>
                                 </div>
                             </Link>
-                        </motion.div>
+                        </div>
                     ))}
-                </motion.div>
+                </div>
             </div>
         </section>
     );

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button";
 import { useSession } from "next-auth/react";
 import { signIn } from "next-auth/react";
 import Link from "next/link";
-import { motion } from "framer-motion";
 import { useTranslationsContext } from "@/context/translations-provider";
 import { useMemo } from "react";
 
@@ -19,65 +18,64 @@ export default function Hero() {
 
     const scrollToGamemodes = () => {
         const gamemodesElement = document.getElementById("gamemodes");
-        console.log(gamemodesElement);
         gamemodesElement?.scrollIntoView({ behavior: "smooth" });
     };
 
     return (
-        <section className="relative min-h-[80vh] flex items-center">
-            <div className="absolute inset-0 bg-[url('/main_bg.webp')] bg-cover bg-center opacity-20 blur-sm"></div>
-            <div className="absolute bottom-0 w-full p-4 bg-black/30 backdrop-blur-sm">
-                <div className="container mx-auto flex flex-col sm:flex-row justify-between items-center gap-4">
-                    <Link href={"https://twitter.com/Akariimia"} target="_blank" className="text-foreground/90 hover:text-primary transition-colors">
+        <section className="relative min-h-[80vh] overflow-hidden flex items-center py-20">
+            <div className="absolute inset-0 bg-[url('/main_bg.webp')] bg-cover bg-center transition-transform duration-700 ease-[var(--ease-out-smooth)]"></div>
+            <div className="absolute inset-0 bg-background/70"></div>
+
+            <div className="container mx-auto px-4 relative z-10">
+                <div className="max-w-4xl mx-auto text-center">
+                    <h1 className="motion-fade-up text-4xl sm:text-5xl md:text-7xl font-bold mb-6 leading-tight">
+                        {titleParts[0]}
+                        <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/70">osu!guessr</span>
+                        {titleParts[1]}
+                    </h1>
+
+                    <p className="motion-fade-up motion-delay-1 text-lg md:text-2xl text-foreground/85 mb-10 leading-relaxed">{t.home.hero.subtitle}</p>
+
+                    <div className="motion-fade-up motion-delay-2 flex flex-col sm:flex-row gap-4 justify-center">
+                        {session ? (
+                            <Button size="lg" onClick={scrollToGamemodes} className="text-base sm:text-lg px-8 w-full sm:w-auto">
+                                {t.home.hero.startPlaying}
+                            </Button>
+                        ) : (
+                            <Button size="lg" onClick={() => signIn("osu")} className="text-base sm:text-lg px-8 w-full sm:w-auto">
+                                {t.home.hero.signIn}
+                            </Button>
+                        )}
+                        <Link href="/about" className="w-full sm:w-auto">
+                            <Button variant="outline" size="lg" className="text-base sm:text-lg px-8 w-full bg-background/60">
+                                {t.home.hero.learnMore}
+                            </Button>
+                        </Link>
+                    </div>
+                </div>
+            </div>
+
+            <div className="absolute bottom-0 w-full p-4 bg-background/55 backdrop-blur-sm border-t border-border/40">
+                <div className="container mx-auto flex flex-col sm:flex-row justify-between items-center gap-3 text-sm sm:text-base">
+                    <Link href={"https://twitter.com/Akariimia"} target="_blank" className="subtle-link text-foreground/90 hover:text-primary transition-colors">
                         {t.home.hero.artCredit}
                     </Link>
 
-                    <div className="flex flex-col sm:flex-row items-center gap-4">
-                        <Link href={"https://osu.ppy.sh/users/yorunoken"} target="_blank" className="flex items-center gap-2 text-foreground/90 hover:text-primary transition-colors">
+                    <div className="flex flex-col sm:flex-row items-center gap-3">
+                        <Link href={"https://osu.ppy.sh/users/yorunoken"} target="_blank" className="subtle-link flex items-center gap-2 text-foreground/90 hover:text-primary transition-colors">
                             <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.436 18.306a.927.927 0 0 1-1.31.001l-3.078-3.08a4.897 4.897 0 0 1-2.048.445 4.91 4.91 0 0 1-4.906-4.906 4.91 4.91 0 0 1 4.906-4.906 4.91 4.91 0 0 1 4.906 4.906c0 .727-.167 1.416-.463 2.033l3.08 3.079a.927.927 0 0 1-.087 1.428z" />
                             </svg>
                             {t.home.hero.developerCredit}
                         </Link>
 
-                        <Link href={"https://discord.gg/qrud2g4CA5"} target="_blank" className="flex items-center gap-2 text-foreground/90 hover:text-primary transition-colors">
+                        <Link href={"https://discord.gg/qrud2g4CA5"} target="_blank" className="subtle-link flex items-center gap-2 text-foreground/90 hover:text-primary transition-colors">
                             <svg viewBox="0 0 24 24" className="w-5 h-5 fill-current" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
                             </svg>
                             {t.home.hero.discordInvite}
                         </Link>
                     </div>
-                </div>
-            </div>
-
-            <div className="container mx-auto px-4 relative z-10">
-                <div className="max-w-4xl mx-auto text-center">
-                    <motion.h1 initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }} className="text-5xl md:text-7xl font-bold mb-6">
-                        {titleParts[0]}
-                        <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/60">osu!guessr</span>
-                        {titleParts[1]}
-                    </motion.h1>
-
-                    <motion.p initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.2 }} className="text-xl md:text-2xl text-foreground/80 mb-12 leading-relaxed">
-                        {t.home.hero.subtitle}
-                    </motion.p>
-
-                    <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4, delay: 0.4 }} className="flex flex-col sm:flex-row gap-4 justify-center">
-                        {session ? (
-                            <Button size="lg" onClick={scrollToGamemodes} className="text-lg px-8 w-full sm:w-auto">
-                                {t.home.hero.startPlaying}
-                            </Button>
-                        ) : (
-                            <Button size="lg" onClick={() => signIn("osu")} className="text-lg px-8 w-full sm:w-auto">
-                                {t.home.hero.signIn}
-                            </Button>
-                        )}
-                        <Link href="/about">
-                            <Button variant="outline" size="lg" className="text-lg px-8 w-full sm:w-auto">
-                                {t.home.hero.learnMore}
-                            </Button>
-                        </Link>
-                    </motion.div>
                 </div>
             </div>
         </section>

--- a/src/app/components/StatsCard.tsx
+++ b/src/app/components/StatsCard.tsx
@@ -1,6 +1,3 @@
-import { motion } from "framer-motion";
-import { useInView } from "react-intersection-observer";
-
 interface StatsCardProps {
     title: string;
     value: string;
@@ -9,71 +6,16 @@ interface StatsCardProps {
 }
 
 export function StatsCard({ title, value, description, icon }: StatsCardProps) {
-    const [ref, inView] = useInView({
-        triggerOnce: true,
-        threshold: 0.2,
-    });
-
-    const cardVariants = {
-        hidden: {
-            opacity: 0,
-            y: 10,
-        },
-        visible: {
-            opacity: 1,
-            y: 0,
-            transition: {
-                duration: 0.4,
-            },
-        },
-    } as const;
-
-    const contentVariants = {
-        hidden: {
-            opacity: 0,
-        },
-        visible: {
-            opacity: 1,
-            transition: {
-                delay: 0.1,
-                duration: 0.3,
-            },
-        },
-    };
-
-    const numberVariants = {
-        hidden: {
-            opacity: 0,
-            y: 5,
-        },
-        visible: {
-            opacity: 1,
-            y: 0,
-            transition: {
-                delay: 0.2,
-                duration: 0.3,
-            },
-        },
-    };
-
     return (
-        <motion.div
-            ref={ref}
-            variants={cardVariants}
-            initial="hidden"
-            animate={inView ? "visible" : "hidden"}
-            className="bg-card rounded-xl p-6 border border-border/50 transition-colors duration-200 hover:bg-card/80"
-        >
-            <div className="flex items-center gap-4">
-                <div className="p-3 rounded-lg bg-primary/10 text-primary">{icon}</div>
-                <motion.div variants={contentVariants}>
-                    <h3 className="text-lg font-semibold">{title}</h3>
-                    <motion.p variants={numberVariants} className="text-3xl font-bold text-primary">
-                        {value}
-                    </motion.p>
+        <div className="interactive-surface group rounded-lg border border-border/60 bg-card p-4 hover:border-primary/25 hover:bg-card/80 sm:p-5">
+            <div className="flex items-start gap-3">
+                <div className="rounded-lg bg-primary/10 p-2.5 text-primary ring-1 ring-primary/15 transition-[background-color,box-shadow,transform] duration-200 ease-[var(--ease-out-smooth)] group-hover:scale-[1.03] group-hover:bg-primary/15 group-hover:shadow-[0_0_0_4px_hsl(var(--primary)/0.06)]">{icon}</div>
+                <div className="min-w-0">
+                    <h3 className="font-semibold">{title}</h3>
+                    <p className="text-2xl font-bold leading-tight text-primary">{value}</p>
                     <p className="text-sm text-foreground/70 mt-1">{description}</p>
-                </motion.div>
+                </div>
             </div>
-        </motion.div>
+        </div>
     );
 }

--- a/src/app/components/Supporters.tsx
+++ b/src/app/components/Supporters.tsx
@@ -1,107 +1,50 @@
-import { motion } from "framer-motion";
+"use client";
+
 import { SupportPageLink } from "@/components/SupportDialogWrapper";
 import { supporters } from "@/config/supporters";
 import { useTranslationsContext } from "@/context/translations-provider";
 import React from "react";
 
-const StyledGameName = () => (
-    <motion.span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/60" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }}>
-        osu!guessr
-    </motion.span>
-);
+const StyledGameName = () => <span className="bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/60">osu!guessr</span>;
 
 export function SupportersSection() {
     const { t } = useTranslationsContext();
 
-    const containerVariants = {
-        hidden: { opacity: 0 },
-        visible: {
-            opacity: 1,
-            transition: {
-                when: "beforeChildren",
-                staggerChildren: 0.1,
-                duration: 0.3,
-            },
-        },
-    };
-
-    const cardVariants = {
-        hidden: {
-            opacity: 0,
-            y: 10,
-        },
-        visible: {
-            opacity: 1,
-            y: 0,
-            transition: {
-                duration: 0.4,
-            },
-        },
-    };
-
     return (
-        <motion.div className="container mx-auto px-4" initial="hidden" whileInView="visible" viewport={{ once: true, margin: "-100px" }} variants={containerVariants}>
-            <motion.div className="flex flex-col items-center gap-4 mb-8" initial={{ opacity: 0, y: -10 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} transition={{ duration: 0.4 }}>
-                <h2 className="text-3xl font-bold text-center">{t.home.supporters.title}</h2>
-                <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} transition={{ duration: 0.2 }}>
-                    <SupportPageLink />
-                </motion.div>
-            </motion.div>
+        <div className="container mx-auto px-4">
+            <div className="mb-6 flex flex-col items-center gap-3">
+                <h2 className="text-center text-2xl font-bold">{t.home.supporters.title}</h2>
+                <SupportPageLink />
+            </div>
 
             {supporters.length > 0 ? (
-                <motion.div
-                    className="grid grid-cols-1 md:grid-cols-3 gap-6"
-                    variants={{
-                        visible: {
-                            transition: {
-                                staggerChildren: 0.1,
-                            },
-                        },
-                    }}
-                >
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                     {supporters.map((supporter, index) => (
-                        <motion.div
-                            key={index}
-                            variants={cardVariants}
-                            whileHover={{
-                                y: -2,
-                                transition: { duration: 0.2 },
-                            }}
-                            className="bg-card rounded-xl p-6 border border-border/50 hover:border-primary/50 transition-colors"
-                        >
-                            <motion.div className="flex items-center gap-3 mb-2" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.2 }}>
+                        <div key={index} className="rounded-lg border border-border/60 bg-card p-4 transition-colors hover:border-primary/50 sm:p-5">
+                            <div className="flex items-center gap-3 mb-2">
                                 <div className="font-semibold">
                                     {supporter.url ? (
-                                        <motion.a
-                                            href={supporter.url}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="hover:text-primary transition-colors"
-                                            whileHover={{ x: 2 }}
-                                            transition={{ duration: 0.2 }}
-                                        >
+                                        <a href={supporter.url} target="_blank" rel="noopener noreferrer" className="hover:text-primary transition-colors">
                                             {supporter.name}
-                                        </motion.a>
+                                        </a>
                                     ) : (
                                         supporter.name
                                     )}
                                 </div>
-                                <motion.div className="text-sm text-primary" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} transition={{ delay: 0.3, duration: 0.2 }}>
-                                    ${supporter.amount}
-                                </motion.div>
-                            </motion.div>
+                                <div className="text-sm text-primary">${supporter.amount}</div>
+                            </div>
                             {supporter.message && (
-                                <motion.p className="text-sm text-foreground/70 italic" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.4, duration: 0.3 }}>
+                                <p className="text-sm text-foreground/70 italic">
                                     {'"'}
                                     {supporter.message}
                                     {'"'}
-                                </motion.p>
+                                </p>
                             )}
-                        </motion.div>
+                        </div>
                     ))}
-                </motion.div>
+                </div>
             ) : (
-                <motion.div className="text-center text-foreground/70" initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.4 }}>
+                <div className="text-center text-foreground/70">
                     <p>
                         {t.home.supporters.beFirst.split("{osu_guessr}").map((part: string, index: number, array: string[]) => (
                             <React.Fragment key={index}>
@@ -110,8 +53,8 @@ export function SupportersSection() {
                             </React.Fragment>
                         ))}
                     </p>
-                </motion.div>
+                </div>
             )}
-        </motion.div>
+        </div>
     );
 }

--- a/src/app/games/ComingSoon.tsx
+++ b/src/app/games/ComingSoon.tsx
@@ -16,10 +16,10 @@ export default function ComingSoon({ mode }: ComingSoonProps) {
     const modeName = modeConfig?.name || mode;
 
     return (
-        <div className="container mx-auto px-4 py-16">
+        <div className="container mx-auto px-4 py-10 md:py-16">
             <div className="max-w-2xl mx-auto text-center">
-                <div className="bg-card rounded-xl p-8 border border-border/50">
-                    <h1 className="text-3xl font-bold mb-6">{t.components.comingSoon.title.replace("{mode}", modeName)}</h1>
+                <div className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
+                    <h1 className="text-2xl sm:text-3xl font-bold mb-6">{t.components.comingSoon.title.replace("{mode}", modeName)}</h1>
 
                     <div className="space-y-6 mb-8">
                         <div className="py-8">
@@ -27,18 +27,20 @@ export default function ComingSoon({ mode }: ComingSoonProps) {
                             <p className="text-foreground/70">{t.components.comingSoon.description.replace("{mode}", modeName.toLowerCase())}</p>
                         </div>
 
-                        <div className="bg-secondary/50 p-6 rounded-lg">
+                        <div className="bg-secondary/50 p-5 sm:p-6 rounded-lg border border-border/50">
                             <h3 className="text-xl font-medium mb-3">{t.components.comingSoon.whatToExpect.title}</h3>
                             <p className="text-foreground/70">{modeConfig?.description || t.components.comingSoon.whatToExpect.skin}</p>
                         </div>
                     </div>
 
-                    <div className="flex justify-center gap-4">
-                        <Link href="/">
-                            <Button>{t.components.comingSoon.actions.home}</Button>
+                    <div className="flex flex-col sm:flex-row justify-center gap-4">
+                        <Link href="/" className="w-full sm:w-auto">
+                            <Button className="w-full sm:w-auto">{t.components.comingSoon.actions.home}</Button>
                         </Link>
-                        <Link href="/games/background">
-                            <Button variant="outline">{t.components.comingSoon.actions.tryBackground}</Button>
+                        <Link href="/games/background" className="w-full sm:w-auto">
+                            <Button variant="outline" className="w-full sm:w-auto">
+                                {t.components.comingSoon.actions.tryBackground}
+                            </Button>
                         </Link>
                     </div>
                 </div>

--- a/src/app/games/shared/components/GameStats.tsx
+++ b/src/app/games/shared/components/GameStats.tsx
@@ -18,29 +18,29 @@ export default function GameStats({ totalPoints, correctGuesses, maxStreak, tota
     const { t } = useTranslationsContext();
 
     return (
-        <div className="container mx-auto px-4 py-16">
+        <div className="container mx-auto px-4 py-10 md:py-16">
             <div className="max-w-2xl mx-auto">
-                <div className="bg-card rounded-xl p-8 border border-border/50">
+                <div className="motion-fade-up bg-card rounded-lg p-5 sm:p-8 border border-border/60 shadow-xl shadow-black/20">
                     {gameVariant === "classic" ? (
                         <>
-                            <h1 className="text-3xl font-bold mb-6">{t.game.stats.classic.title}</h1>
+                            <h1 className="text-2xl sm:text-3xl font-bold mb-6">{t.game.stats.classic.title}</h1>
 
-                            <div className="grid grid-cols-2 gap-4 mb-8">
-                                <div className="bg-secondary/50 p-4 rounded-lg text-center">
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+                                <div className="interactive-surface bg-secondary/50 p-4 rounded-lg text-center border border-border/50">
                                     <div className="text-2xl font-bold text-primary">{totalPoints}</div>
                                     <div className="text-sm text-foreground/70">{t.game.stats.classic.totalPoints}</div>
                                 </div>
-                                <div className="bg-secondary/50 p-4 rounded-lg text-center">
+                                <div className="interactive-surface bg-secondary/50 p-4 rounded-lg text-center border border-border/50">
                                     <div className="text-2xl font-bold text-primary">{maxStreak}</div>
                                     <div className="text-sm text-foreground/70">{t.game.stats.classic.highestStreak}</div>
                                 </div>
-                                <div className="bg-secondary/50 p-4 rounded-lg text-center">
+                                <div className="interactive-surface bg-secondary/50 p-4 rounded-lg text-center border border-border/50">
                                     <div className="text-2xl font-bold text-primary">
                                         {t.game.stats.classic.correctGuesses.replace("{correct}", correctGuesses.toString()).replace("{total}", totalRounds.toString())}
                                     </div>
                                     <div className="text-sm text-foreground/70">{t.game.stats.labels.correctGuesses}</div>
                                 </div>
-                                <div className="bg-secondary/50 p-4 rounded-lg text-center">
+                                <div className="interactive-surface bg-secondary/50 p-4 rounded-lg text-center border border-border/50">
                                     <div className="text-2xl font-bold text-primary">{t.game.stats.classic.averageTime.replace("{time}", averageTime.toFixed(1))}</div>
                                     <div className="text-sm text-foreground/70">{t.game.stats.labels.averageTime}</div>
                                 </div>
@@ -48,17 +48,17 @@ export default function GameStats({ totalPoints, correctGuesses, maxStreak, tota
                         </>
                     ) : (
                         <>
-                            <h1 className={`text-3xl font-bold mb-6 ${gameEndReason === "died" ? "text-destructive" : "text-primary"}`}>
+                            <h1 className={`text-2xl sm:text-3xl font-bold mb-6 ${gameEndReason === "died" ? "text-destructive" : "text-primary"}`}>
                                 {gameEndReason === "died" ? t.game.stats.death.title.died : t.game.stats.death.title.completed}
                             </h1>
 
                             <div className="grid grid-cols-1 gap-6 mb-8">
-                                <div className="bg-secondary/50 p-6 rounded-lg text-center">
+                                <div className="interactive-surface bg-secondary/50 p-6 rounded-lg text-center border border-border/50">
                                     <div className="text-4xl font-bold text-primary mb-2">{maxStreak}</div>
                                     <div className="text-lg text-foreground/70">{t.game.stats.death.maxStreak}</div>
                                 </div>
 
-                                <div className="bg-secondary/50 p-4 rounded-lg grid grid-cols-2 gap-4">
+                                <div className="bg-secondary/50 p-4 rounded-lg grid grid-cols-1 sm:grid-cols-2 gap-4 border border-border/50">
                                     <div className="text-center">
                                         <div className="text-2xl font-bold text-primary">{correctGuesses}</div>
                                         <div className="text-sm text-foreground/70">{t.game.stats.death.totalCorrect}</div>
@@ -70,7 +70,7 @@ export default function GameStats({ totalPoints, correctGuesses, maxStreak, tota
                                 </div>
 
                                 {gameEndReason === "died" && (
-                                    <div className="bg-destructive/10 p-4 rounded-lg text-center">
+                                    <div className="bg-destructive/10 p-4 rounded-lg text-center border border-destructive/20">
                                         <p className="text-destructive font-medium">{t.game.stats.death.diedMessage}</p>
                                     </div>
                                 )}
@@ -78,7 +78,7 @@ export default function GameStats({ totalPoints, correctGuesses, maxStreak, tota
                         </>
                     )}
 
-                    <div className="flex gap-4">
+                    <div className="flex flex-col sm:flex-row gap-4">
                         <Button onClick={onPlayAgain} className="flex-1" variant={gameVariant === "death" ? "destructive" : "default"}>
                             {t.game.stats.actions.tryAgain}
                         </Button>

--- a/src/app/games/shared/components/GuessInput.tsx
+++ b/src/app/games/shared/components/GuessInput.tsx
@@ -2,7 +2,6 @@ import { Button } from "@/components/ui/button";
 import { useState, useEffect, useRef } from "react";
 import { GameClient } from "@/lib/game/client";
 import { useTranslationsContext } from "@/context/translations-provider";
-import { motion, AnimatePresence } from "framer-motion";
 import { soundManager } from "@/lib/game/sounds";
 
 interface GuessInputProps {
@@ -146,7 +145,7 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
     };
 
     return (
-        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="bg-card p-6 rounded-xl border border-border/50">
+        <div className="motion-fade-up bg-card p-6 rounded-xl border border-border/50">
             <h2 className="text-xl font-semibold mb-4">{t.game.input.title}</h2>
             <div className="relative">
                 <input
@@ -163,53 +162,45 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
                             }
                         });
                     }}
-                    className="w-full p-3 rounded-lg bg-secondary text-foreground border border-border/50 focus:outline-none focus:ring-2 focus:ring-primary"
+                    className="w-full p-3 rounded-lg bg-secondary text-foreground border border-border/50 transition-[border-color,box-shadow,background-color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:outline-none focus:border-primary/55 focus:ring-2 focus:ring-primary focus:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)] disabled:opacity-60"
                     placeholder={t.game.input.placeholder}
                     disabled={isRevealed}
                 />
 
-                <AnimatePresence>
-                    {showSuggestions && suggestions.length > 0 && (
-                        <motion.div
-                            initial={{ opacity: 0, y: -10 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -10 }}
-                            transition={{ duration: 0.15 }}
-                            className="absolute w-full mt-1 bg-card border border-border/50 rounded-lg shadow-lg overflow-hidden z-50"
-                        >
-                            <div className="max-h-[300px] overflow-y-auto backdrop-blur-sm">
-                                {suggestions.map((suggestion, index) => (
-                                    <div
-                                        key={suggestion}
-                                        className={`px-4 py-2 cursor-pointer transition-colors duration-150
+                {showSuggestions && suggestions.length > 0 && (
+                    <div className="motion-scale-in absolute w-full mt-1 bg-card border border-border/50 rounded-lg shadow-lg overflow-hidden z-50 origin-top">
+                        <div className="max-h-[300px] overflow-y-auto backdrop-blur-sm">
+                            {suggestions.map((suggestion, index) => (
+                                <div
+                                    key={suggestion}
+                                    className={`px-4 py-2 cursor-pointer transition-[background-color,color] duration-150 ease-[var(--ease-out-smooth)]
                                                ${index === selectedIndex ? "bg-primary/10 text-primary font-medium" : "hover:bg-secondary/50"}`}
-                                        onMouseDown={() => {
-                                            clickingRef.current = true;
-                                        }}
-                                        onMouseUp={() => {
-                                            clickingRef.current = false;
-                                            handleSuggestionSelect(suggestion);
-                                        }}
-                                        onMouseEnter={() => setSelectedIndex(index)}
-                                    >
-                                        {suggestion}
-                                    </div>
-                                ))}
-                            </div>
-                        </motion.div>
-                    )}
-                </AnimatePresence>
+                                    onMouseDown={() => {
+                                        clickingRef.current = true;
+                                    }}
+                                    onMouseUp={() => {
+                                        clickingRef.current = false;
+                                        handleSuggestionSelect(suggestion);
+                                    }}
+                                    onMouseEnter={() => setSelectedIndex(index)}
+                                >
+                                    {suggestion}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
             </div>
             <div className="flex gap-4 mt-4">
                 <Button className="flex-1" onClick={onGuess} disabled={!guess || isRevealed}>
                     {t.game.input.submit}
                 </Button>
-                <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} className="flex-1">
+                <div className="flex-1">
                     <Button variant="outline" onClick={handleSkip} disabled={isRevealed} className="w-full hover:bg-destructive/10 hover:text-destructive hover:border-destructive/50 transition-colors">
                         {t.game.input.skip}
                     </Button>
-                </motion.div>
+                </div>
             </div>
-        </motion.div>
+        </div>
     );
 }

--- a/src/app/games/shared/components/Header.tsx
+++ b/src/app/games/shared/components/Header.tsx
@@ -15,17 +15,18 @@ interface GameHeaderProps {
 
 export default function GameHeader({ streak, points, timeLeft, currentRound, totalRounds, mode, gameVariant, maxStreak = 0, lives = 1 }: GameHeaderProps) {
     const { t } = useTranslationsContext();
+    const pillClass = "bg-primary/10 text-primary px-4 py-1.5 rounded-full ring-1 ring-primary/15 transition-[background-color,box-shadow] duration-150 ease-[var(--ease-out-smooth)]";
 
     const getLivesDisplay = (lives: number) => {
         if (lives === 1) {
             return (
-                <div className="bg-primary/10 text-primary px-4 py-1 rounded-full">
+                <div className={pillClass}>
                     <span className="font-semibold">{t.game.header.death.lives.oneShot}</span>
                 </div>
             );
         } else {
             return (
-                <div className="bg-destructive/20 text-destructive px-4 py-1 rounded-full">
+                <div className="bg-destructive/20 text-destructive px-4 py-1.5 rounded-full ring-1 ring-destructive/20 transition-[background-color,box-shadow] duration-150 ease-[var(--ease-out-smooth)]">
                     <span className="font-semibold">{t.game.header.death.lives.gameOver}</span>
                 </div>
             );
@@ -33,35 +34,35 @@ export default function GameHeader({ streak, points, timeLeft, currentRound, tot
     };
 
     return (
-        <div className="flex justify-between items-center mb-8">
-            <div className="flex items-center gap-4">
-                <h1 className="text-3xl font-bold capitalize">{t.game.header.title.replace("{mode}", mode)}</h1>
+        <div className="motion-fade-up flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between mb-8 rounded-lg border border-border/60 bg-card/50 p-4">
+            <div className="flex flex-wrap items-center gap-3">
+                <h1 className="w-full text-2xl font-bold capitalize sm:w-auto sm:text-3xl">{t.game.header.title.replace("{mode}", mode)}</h1>
 
                 {gameVariant === "classic" ? (
                     <>
-                        <div className="bg-primary/10 text-primary px-4 py-1 rounded-full">
+                        <div className={pillClass}>
                             <span className="font-semibold">{t.game.header.classic.round.replace("{current}", currentRound.toString()).replace("{total}", totalRounds.toString())}</span>
                         </div>
-                        <div className="bg-primary/10 text-primary px-4 py-1 rounded-full">
+                        <div className={pillClass}>
                             <span className="font-semibold">{t.game.header.classic.streak.replace("{count}", streak.toString())}</span>
                         </div>
-                        <div className="bg-primary/10 text-primary px-4 py-1 rounded-full">
+                        <div className={pillClass}>
                             <span className="font-semibold">{t.game.header.classic.points.replace("{count}", points.toString())}</span>
                         </div>
                     </>
                 ) : (
                     <>
                         {getLivesDisplay(lives)}
-                        <div className="bg-primary/10 text-primary px-4 py-1 rounded-full">
+                        <div className={pillClass}>
                             <span className="font-semibold">{t.game.header.death.currentStreak.replace("{count}", streak.toString())}</span>
                         </div>
-                        <div className="bg-primary/10 text-primary px-4 py-1 rounded-full">
+                        <div className={pillClass}>
                             <span className="font-semibold">{t.game.header.death.maxStreak.replace("{count}", maxStreak.toString())}</span>
                         </div>
                     </>
                 )}
             </div>
-            <div className="text-2xl font-mono">
+            <div className="self-start rounded-lg bg-secondary/80 px-4 py-2 text-xl font-mono ring-1 ring-border/70 transition-[box-shadow,background-color] duration-150 ease-[var(--ease-out-smooth)] lg:self-auto">
                 <span className={timeLeft < 10 ? "text-destructive" : "text-foreground"}>{t.game.header.timeLeft.replace("{seconds}", timeLeft.toString())}</span>
             </div>
         </div>

--- a/src/app/games/shared/components/LoadingScreen.tsx
+++ b/src/app/games/shared/components/LoadingScreen.tsx
@@ -4,10 +4,10 @@ export default function LoadingScreen() {
     const { t } = useTranslationsContext();
 
     return (
-        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex flex-col items-center justify-center z-10">
+        <div className="absolute inset-0 bg-background/80 backdrop-blur-sm flex flex-col items-center justify-center z-10 motion-scale-in">
             <div className="flex flex-col items-center gap-4">
                 <div className="relative">
-                    <div className="w-12 h-12 border-4 border-primary/30 border-t-primary rounded-full animate-spin"></div>
+                    <div className="w-12 h-12 border-4 border-primary/25 border-t-primary rounded-full animate-spin"></div>
                 </div>
                 <p className="text-lg font-medium text-foreground/70">{t.game.status.loading}</p>
             </div>

--- a/src/app/games/shared/components/Result.tsx
+++ b/src/app/games/shared/components/Result.tsx
@@ -1,61 +1,30 @@
 import { GameMediaProps } from "@/lib/game/interfaces";
-import { motion } from "framer-motion";
 
 export const ResultMessage = ({ result }: { result: GameMediaProps["result"] }) => {
     if (!result) return null;
 
-    const variants = {
-        correct: {
-            scale: [1, 1.2, 1],
-            transition: { duration: 0.5 },
-        },
-        wrong: {
-            x: [-10, 10, -10, 10, 0],
-            transition: { duration: 0.5 },
-        },
-        skip: {
-            y: [-10, 0],
-            opacity: [0, 1],
-            transition: { duration: 0.3 },
-        },
-        timeout: {
-            scale: [1, 0.95, 1],
-            opacity: [0, 1],
-            transition: { duration: 0.4 },
-        },
-    };
-
     let message = "";
     let colorClass = "";
-    let animation = "correct";
 
     switch (result.type) {
         case "guess":
             if (result.correct) {
                 message = "Correct Guess!";
                 colorClass = "text-green-500";
-                animation = "correct";
             } else {
                 message = "Wrong Guess!";
                 colorClass = "text-destructive";
-                animation = "wrong";
             }
             break;
         case "skip":
             message = "Skipped";
             colorClass = "text-yellow-500";
-            animation = "skip";
             break;
         case "timeout":
             message = "Time's Up!";
             colorClass = "text-destructive";
-            animation = "timeout";
             break;
     }
 
-    return (
-        <motion.div variants={variants} animate={animation} className={`text-2xl font-bold mb-4 ${colorClass}`}>
-            {message}
-        </motion.div>
-    );
+    return <div className={`text-2xl font-bold mb-4 ${colorClass}`}>{message}</div>;
 };

--- a/src/app/games/shared/pages/GameScreen.tsx
+++ b/src/app/games/shared/pages/GameScreen.tsx
@@ -245,7 +245,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
     }
 
     return (
-        <div className="container mx-auto px-4 py-8">
+        <div className="container mx-auto px-4 py-6 md:py-8">
             <GameHeader
                 streak={gameState.score.streak}
                 points={gameState.score.total}
@@ -257,7 +257,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                 maxStreak={gameState.score.highestStreak}
             />
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
                 <div className="relative">
                     <GameMedia
                         mediaUrl={gameMode === "audio" ? gameState.currentBeatmap.audioUrl! : gameState.currentBeatmap.imageUrl!}
@@ -272,7 +272,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                 <div className="flex flex-col gap-6">
                     <GuessInput guess={guess} setGuess={setGuess} isRevealed={gameState.currentBeatmap.revealed} onGuess={handleGuess} onSkip={handleSkip} gameClient={gameClient.current!} />
 
-                    <div className="bg-card p-6 rounded-xl border border-border/50">
+                    <div className="bg-card p-6 rounded-lg border border-border/60">
                         <h3 className="font-semibold mb-2">{t.game.shortcuts.title}</h3>
                         <ul className="list-disc list-inside space-y-1 text-foreground/70">
                             <li>{t.game.shortcuts.items.tab}</li>
@@ -285,7 +285,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                 </div>
             </div>
 
-            <div className="flex justify-between mt-8">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mt-8">
                 <div className="flex gap-2">
                     <Button variant="outline" onClick={handleExit} disabled={isLoading}>
                         {gameVariant === "death" ? t.game.actions.endRun : t.game.actions.exitGame}

--- a/src/app/games/shared/pages/PreGameMenu.tsx
+++ b/src/app/games/shared/pages/PreGameMenu.tsx
@@ -18,12 +18,14 @@ export default function PreGameMenu({ onStart, gameMode }: PreGameMenuProps) {
 
     const descriptions = t.game.preGame.description as Record<string, string>;
     const gameDescription = descriptions[gameMode] || descriptions.background;
+    const sectionTitleClass = "mb-3 text-lg font-semibold";
+    const listClass = "flex flex-col gap-2 text-foreground/70";
 
     const ClassicModeContent = () => (
         <>
             <div>
-                <h2 className="text-xl font-semibold mb-3">{t.game.preGame.howToPlay.title}</h2>
-                <ul className="space-y-2 text-foreground/70">
+                <h2 className={sectionTitleClass}>{t.game.preGame.howToPlay.title}</h2>
+                <ul className={listClass}>
                     <li>• {gameDescription}</li>
                     <li>• {t.game.preGame.howToPlay.classic.rounds.replace("{count}", MAX_ROUNDS.toString())}</li>
                     <li>• {t.game.preGame.howToPlay.classic.time.replace("{seconds}", ROUND_TIME.toString())}</li>
@@ -33,8 +35,8 @@ export default function PreGameMenu({ onStart, gameMode }: PreGameMenuProps) {
             </div>
 
             <div>
-                <h2 className="text-xl font-semibold mb-3">{t.game.preGame.scoring.title}</h2>
-                <ul className="space-y-2 text-foreground/70">
+                <h2 className={sectionTitleClass}>{t.game.preGame.scoring.title}</h2>
+                <ul className={listClass}>
                     <li>• {t.game.preGame.scoring.classic.base.replace("{points}", BASE_POINTS.toString())}</li>
                     <li>• {t.game.preGame.scoring.classic.timeBonus.replace("{points}", TIME_BONUS_MULTIPLIER.toString())}</li>
                     <li>• {t.game.preGame.scoring.classic.streakBonus.replace("{points}", STREAK_BONUS.toString())}</li>
@@ -47,8 +49,8 @@ export default function PreGameMenu({ onStart, gameMode }: PreGameMenuProps) {
     const DeathModeContent = () => (
         <>
             <div>
-                <h2 className="text-xl font-semibold mb-3">{t.game.preGame.howToPlay.title}</h2>
-                <ul className="space-y-2 text-foreground/70">
+                <h2 className={sectionTitleClass}>{t.game.preGame.howToPlay.title}</h2>
+                <ul className={listClass}>
                     <li>• {gameDescription}</li>
                     <li>• {t.game.preGame.howToPlay.death.continuous}</li>
                     <li>• {t.game.preGame.howToPlay.death.time.replace("{seconds}", ROUND_TIME.toString())}</li>
@@ -57,8 +59,8 @@ export default function PreGameMenu({ onStart, gameMode }: PreGameMenuProps) {
             </div>
 
             <div>
-                <h2 className="text-xl font-semibold mb-3">{t.game.preGame.scoring.title}</h2>
-                <ul className="space-y-2 text-foreground/70">
+                <h2 className={sectionTitleClass}>{t.game.preGame.scoring.title}</h2>
+                <ul className={listClass}>
                     <li>• {t.game.preGame.scoring.death.streakOnly}</li>
                     <li>• {t.game.preGame.scoring.death.noPoints}</li>
                     <li>• {t.game.preGame.scoring.death.compete}</li>
@@ -68,38 +70,39 @@ export default function PreGameMenu({ onStart, gameMode }: PreGameMenuProps) {
     );
 
     return (
-        <div className="container mx-auto px-4 py-16">
-            <div className="max-w-2xl mx-auto">
-                <div className="bg-card rounded-xl p-8 border border-border/50">
-                    <h1 className="text-3xl font-bold mb-6">{t.game.preGame.title[gameMode as keyof typeof t.game.preGame.title]}</h1>
+        <div className="container mx-auto px-4 py-10 md:py-16">
+            <div className="max-w-3xl mx-auto">
+                <div className="bg-card rounded-lg p-5 sm:p-6 border border-border/60 shadow-xl shadow-black/20">
+                    <h1 className="text-2xl sm:text-3xl font-bold mb-6">{t.game.preGame.title[gameMode as keyof typeof t.game.preGame.title]}</h1>
 
-                    <div className="grid grid-cols-2 gap-4 mb-8">
-                        <Button onClick={() => setSelectedMode("classic")} variant={selectedMode === "classic" ? "default" : "outline"} className="flex-1 h-auto py-6 flex flex-col gap-2">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+                        <Button onClick={() => setSelectedMode("classic")} variant={selectedMode === "classic" ? "default" : "outline"} className="h-auto min-h-24 flex-col items-start gap-2 whitespace-normal p-4 text-left active:!transform-none data-[selected=true]:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)]" data-selected={selectedMode === "classic"}>
                             <span className="text-lg font-semibold">{t.game.preGame.modes.classic.title}</span>
-                            <span className="text-sm text-muted-foreground">{t.game.preGame.modes.classic.description}</span>
+                            <span className={selectedMode === "classic" ? "text-sm text-primary-foreground/80" : "text-sm text-muted-foreground"}>{t.game.preGame.modes.classic.description}</span>
                         </Button>
                         <Button
                             onClick={() => setSelectedMode("death")}
                             variant={selectedMode === "death" ? "destructive" : "outline"}
-                            className="flex-1 h-auto py-6 flex flex-col gap-2 hover:bg-red-500 hover:text-white transition-colors"
+                            className="h-auto min-h-24 flex-col items-start gap-2 whitespace-normal p-4 text-left active:!transform-none hover:bg-destructive/15 hover:text-destructive hover:border-destructive/50 data-[selected=true]:shadow-[0_0_0_4px_hsl(var(--destructive)/0.08)]"
+                            data-selected={selectedMode === "death"}
                         >
                             <span className="text-lg font-semibold">{t.game.preGame.modes.death.title}</span>
-                            <span className="text-sm text-muted-foreground">{t.game.preGame.modes.death.description}</span>
+                            <span className={selectedMode === "death" ? "text-sm text-destructive-foreground/80" : "text-sm text-muted-foreground"}>{t.game.preGame.modes.death.description}</span>
                         </Button>
                     </div>
 
-                    <div className="space-y-6 mb-8">
+                    <div className="mb-6 flex min-h-[22rem] flex-col gap-5 sm:min-h-[18rem]">
                         {selectedMode === "classic" ? <ClassicModeContent /> : <DeathModeContent />}
 
                         {selectedMode === "classic" && (
-                            <div className="bg-destructive/10 p-4 rounded-lg">
+                            <div className="bg-destructive/10 p-4 rounded-lg border border-destructive/20">
                                 <h2 className="text-xl font-semibold mb-2 text-destructive">{t.game.preGame.warning.title}</h2>
                                 <p className="text-foreground/70">{t.game.preGame.warning.description.replace("{rounds}", MAX_ROUNDS.toString())}</p>
                             </div>
                         )}
                     </div>
 
-                    <div className="flex gap-4">
+                    <div className="flex flex-col sm:flex-row gap-4">
                         <Button onClick={() => onStart(selectedMode)} className="flex-1" variant={selectedMode === "death" ? "destructive" : "default"}>
                             {t.game.preGame.actions.startGame}
                         </Button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,10 +28,142 @@ body {
         --input: 0 0% 14.9%;
         --ring: 252 100% 69%;
         --radius: 0.75rem;
+        --ease-out-smooth: cubic-bezier(0.16, 1, 0.3, 1);
+        --ease-press: cubic-bezier(0.34, 1.56, 0.64, 1);
     }
 }
 
 @layer utilities {
+    @keyframes osu-fade-up {
+        from {
+            opacity: 0;
+            transform: translateY(8px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    @keyframes osu-scale-in {
+        from {
+            opacity: 0;
+            transform: scale(0.98);
+        }
+        to {
+            opacity: 1;
+            transform: scale(1);
+        }
+    }
+
+    @keyframes osu-soft-pulse {
+        0%,
+        100% {
+            opacity: 0.72;
+            transform: scale(1);
+        }
+        50% {
+            opacity: 1;
+            transform: scale(1.04);
+        }
+    }
+
+    .motion-fade-up {
+        animation: osu-fade-up 420ms var(--ease-out-smooth) both;
+    }
+
+    .motion-scale-in {
+        animation: osu-scale-in 220ms var(--ease-out-smooth) both;
+    }
+
+    .motion-delay-1 {
+        animation-delay: 80ms;
+    }
+
+    .motion-delay-2 {
+        animation-delay: 150ms;
+    }
+
+    .motion-delay-3 {
+        animation-delay: 220ms;
+    }
+
+    .interactive-surface {
+        transition:
+            border-color 180ms var(--ease-out-smooth),
+            background-color 180ms var(--ease-out-smooth),
+            box-shadow 180ms var(--ease-out-smooth),
+            transform 180ms var(--ease-out-smooth);
+    }
+
+    .interactive-surface:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 18px 50px -34px hsl(var(--primary) / 0.6);
+    }
+
+    .interactive-surface:active {
+        transform: translateY(0);
+    }
+
+    .press-feedback {
+        transition:
+            transform 120ms var(--ease-press),
+            box-shadow 160ms var(--ease-out-smooth),
+            background-color 160ms var(--ease-out-smooth),
+            border-color 160ms var(--ease-out-smooth),
+            color 160ms var(--ease-out-smooth),
+            opacity 160ms var(--ease-out-smooth);
+    }
+
+    .press-feedback:active:not(:disabled) {
+        transform: translateY(1px) scale(0.99);
+    }
+
+    .subtle-link {
+        position: relative;
+    }
+
+    .subtle-link::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: -0.25rem;
+        height: 1px;
+        background: hsl(var(--primary));
+        transform: scaleX(0);
+        transform-origin: left;
+        transition: transform 180ms var(--ease-out-smooth);
+    }
+
+    .subtle-link:hover::after,
+    .subtle-link:focus-visible::after {
+        transform: scaleX(1);
+    }
+
+    .soft-loading-dot {
+        animation: osu-soft-pulse 1.4s var(--ease-out-smooth) infinite;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .motion-fade-up,
+        .motion-scale-in,
+        .soft-loading-dot {
+            animation: none;
+        }
+
+        .interactive-surface,
+        .press-feedback,
+        .subtle-link::after {
+            transition-duration: 1ms;
+        }
+
+        .interactive-surface:hover,
+        .press-feedback:active:not(:disabled) {
+            transform: none;
+        }
+    }
+
     .scrollbar-thin {
         scrollbar-width: thin;
     }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Public_Sans } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 import { SessionWrapper } from "@/context/session-wrapper";
 import { ThemeProvider } from "@/context/theme-provider";
@@ -40,6 +41,17 @@ export const metadata: Metadata = {
     },
 };
 
+function AnalyticsScripts() {
+    if (process.env.NODE_ENV !== "production") return null;
+
+    return (
+        <>
+            <Script src="https://umami.yorunoken.com/script.js" data-website-id="43244628-cb56-43d3-936e-0edbc45d4790" strategy="afterInteractive" />
+            <Script src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3511683752810096" crossOrigin="anonymous" strategy="afterInteractive" />
+        </>
+    );
+}
+
 export default async function RootLayout({
     children,
 }: Readonly<{
@@ -51,10 +63,6 @@ export default async function RootLayout({
     if (lock && session?.user?.banchoId !== OWNER_ID) {
         return (
             <html lang="en">
-                <head>
-                    <script defer src="https://umami.yorunoken.com/script.js" data-website-id="43244628-cb56-43d3-936e-0edbc45d4790"></script>
-                    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3511683752810096" crossOrigin="anonymous"></script>
-                </head>
                 <body className={`${publicSans.variable} antialiased`}>
                     <div className="flex items-center justify-center min-h-screen bg-background">
                         <div className="max-w-xl mx-auto p-8 bg-card rounded-lg border border-border">
@@ -63,6 +71,7 @@ export default async function RootLayout({
                             <p className="text-sm text-muted-foreground">Access is restricted. Only the owner can access the site while it&apos;s locked. Sorry for the inconvenience.</p>
                         </div>
                     </div>
+                    <AnalyticsScripts />
                 </body>
             </html>
         );
@@ -71,10 +80,9 @@ export default async function RootLayout({
     return (
         <html lang="en">
             <head>
-                <script defer src="https://umami.yorunoken.com/script.js" data-website-id="43244628-cb56-43d3-936e-0edbc45d4790"></script>
-                <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3511683752810096" crossOrigin="anonymous"></script>
                 {/* JSON-LD structured data for Site */}
                 <script
+                    type="application/ld+json"
                     dangerouslySetInnerHTML={{
                         __html: JSON.stringify({
                             "@context": "https://schema.org",
@@ -94,16 +102,16 @@ export default async function RootLayout({
                 <TranslationsProvider>
                     <SessionWrapper>
                         <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
-                            <Header />
-
-                            <div className="flex flex-col min-h-screen">
+                            <div className="flex min-h-screen flex-col bg-background text-foreground">
+                                <Header />
                                 <main className="flex-grow">{children}</main>
+                                <Footer />
                             </div>
-                            <Footer />
                             <Toaster />
                         </ThemeProvider>
                     </SessionWrapper>
                 </TranslationsProvider>
+                <AnalyticsScripts />
             </body>
         </html>
     );

--- a/src/app/leaderboard/client.tsx
+++ b/src/app/leaderboard/client.tsx
@@ -51,11 +51,11 @@ export default function LeaderboardClient() {
     const gameModes: GameMode[] = [GameMode.Background, GameMode.Audio, GameMode.Skin];
 
     return (
-        <div className="container mx-auto px-4 py-16">
-            <h1 className="text-4xl font-bold mb-8 text-center">{t.leaderboard.title}</h1>
+        <div className="container mx-auto px-4 py-10 md:py-16">
+            <h1 className="text-3xl md:text-4xl font-bold mb-8 text-center">{t.leaderboard.title}</h1>
 
-            <div className="flex flex-wrap items-center justify-center gap-4 mb-8 p-4 bg-card rounded-lg border">
-                <div className="flex items-center gap-2">
+            <div className="flex flex-col md:flex-row md:flex-wrap items-stretch md:items-center justify-center gap-4 mb-8 p-4 bg-card rounded-lg border border-border/60">
+                <div className="flex items-center justify-between gap-2 md:justify-start">
                     <span className="text-sm font-medium text-muted-foreground">Mode:</span>
                     <Select value={selectedMode} onValueChange={(value: GameMode) => setSelectedMode(value)}>
                         <SelectTrigger className="w-32">
@@ -71,9 +71,9 @@ export default function LeaderboardClient() {
                     </Select>
                 </div>
 
-                <div className="flex items-center gap-2">
+                <div className="flex items-center justify-between gap-2 md:justify-start">
                     <span className="text-sm font-medium text-muted-foreground">Variant:</span>
-                    <div className="flex rounded-md border">
+                    <div className="flex rounded-md border border-border/60">
                         <Button variant={selectedVariant === "classic" ? "default" : "ghost"} size="sm" onClick={() => setSelectedVariant("classic")} className="rounded-r-none border-r">
                             {t.leaderboard.filters.variant.classic}
                         </Button>
@@ -84,7 +84,7 @@ export default function LeaderboardClient() {
                 </div>
             </div>
 
-            <div className="bg-card rounded-xl border border-border/50 overflow-hidden">
+            <div className="bg-card rounded-lg border border-border/60 overflow-hidden">
                 <div className="overflow-x-auto">
                     <table className="w-full">
                         <thead className="bg-secondary/50">
@@ -127,10 +127,10 @@ export default function LeaderboardClient() {
                                 </tr>
                             ) : leaderboardData.length > 0 ? (
                                 leaderboardData.map((player, index) => (
-                                    <tr key={index} className={`hover:bg-secondary/20 transition-colors ${session?.user?.name === player.username ? "bg-primary/10" : ""}`}>
+                                    <tr key={player.bancho_id} className={`hover:bg-secondary/20 transition-colors ${session?.user?.name === player.username ? "bg-primary/10" : ""}`}>
                                         <td className="px-6 py-4">
-                                            {(index + 1 <= 3) && page < 1 ? (
-                                                <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-br from-yellow-400 to-yellow-600 text-white font-bold text-sm">
+                                            {index + 1 <= 3 && page === 1 ? (
+                                                <div className="flex items-center justify-center w-8 h-8 rounded-full bg-secondary text-foreground font-bold text-sm ring-1 ring-border/70">
                                                     {(page - 1) * pageSize + index + 1}
                                                 </div>
                                             ) : (
@@ -183,8 +183,8 @@ export default function LeaderboardClient() {
                 </div>
             </div>
 
-            <div className="grid grid-cols-3 items-center gap-4 mt-4">
-                <div />
+            <div className="grid grid-cols-1 md:grid-cols-3 items-center gap-4 mt-4">
+                <div className="hidden md:block" />
 
                 <div className="flex items-center justify-center">
                     <Button size="sm" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
@@ -196,7 +196,7 @@ export default function LeaderboardClient() {
                     </Button>
                 </div>
 
-                <div className="flex items-center justify-end gap-2">
+                <div className="flex items-center justify-center md:justify-end gap-2">
                     <span className="text-sm text-muted-foreground">Page size</span>
                     <Select
                         value={String(pageSize)}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,26 +1,51 @@
 import { Suspense } from "react";
 import Hero from "./components/Hero";
 import GameModeCards from "./components/GameModeCards";
-import HomeContent from "./HomeContent";
-import LoadingFallback from "./LoadingFallback";
+import { HomeAnnouncementsSection, HomeStatsSection } from "./HomeContent";
 import { getHighestStatsAction } from "@/actions/user-server";
 import { readChangelogs } from "@/actions/changelogs";
-import { getLatestAnnouncement, listAnnouncements } from "@/actions/announcements";
+import { listRecentAnnouncements } from "@/actions/announcements";
+import { SupportersSection } from "./components/Supporters";
+import { ChangelogsSection } from "./components/Changelogs";
 
 export const dynamic = "force-dynamic";
 
-export default async function Home() {
-    const [changelogs, highStats, latestAnnouncement, announcementsHistory] = await Promise.all([readChangelogs(), getHighestStatsAction(), getLatestAnnouncement(), listAnnouncements()]);
+async function HomeStats() {
+    const highStats = await getHighestStatsAction();
+    return <HomeStatsSection highStats={highStats} />;
+}
 
+async function HomeAnnouncements() {
+    const announcements = await listRecentAnnouncements(6);
+    return <HomeAnnouncementsSection latestAnnouncement={announcements[0] ?? null} announcementsHistory={announcements} />;
+}
+
+async function HomeChangelogs() {
+    const changelogs = await readChangelogs();
     return (
-        <div className="min-h-screen flex flex-col bg-background text-foreground">
-            <main className="flex-grow">
-                <Hero />
-                <GameModeCards />
-                <Suspense fallback={<LoadingFallback />}>
-                    <HomeContent changelogs={changelogs} highStats={highStats} latestAnnouncement={latestAnnouncement} announcementsHistory={announcementsHistory} />
-                </Suspense>
-            </main>
-        </div>
+        <section className="py-12">
+            <ChangelogsSection changelogs={changelogs} />
+        </section>
+    );
+}
+
+export default function Home() {
+    return (
+        <>
+            <Hero />
+            <GameModeCards />
+            <Suspense fallback={null}>
+                <HomeStats />
+            </Suspense>
+            <Suspense fallback={null}>
+                <HomeAnnouncements />
+            </Suspense>
+            <section className="bg-secondary/20 py-12">
+                <SupportersSection />
+            </section>
+            <Suspense fallback={null}>
+                <HomeChangelogs />
+            </Suspense>
+        </>
     );
 }

--- a/src/app/privacy/client.tsx
+++ b/src/app/privacy/client.tsx
@@ -6,11 +6,11 @@ export default function PrivacyPolicy() {
     const { t } = useTranslationsContext();
 
     return (
-        <div className="container mx-auto px-4 py-16 max-w-4xl">
-            <h1 className="text-4xl font-bold mb-8">{t.privacy.title}</h1>
+        <div className="container mx-auto px-4 py-10 md:py-16 max-w-4xl">
+            <h1 className="text-3xl md:text-4xl font-bold mb-8">{t.privacy.title}</h1>
 
             <div className="space-y-8">
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.privacy.sections.dataCollection.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.privacy.sections.dataCollection.description}</p>
@@ -22,7 +22,7 @@ export default function PrivacyPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.privacy.sections.dataUsage.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.privacy.sections.dataUsage.description}</p>
@@ -34,7 +34,7 @@ export default function PrivacyPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.privacy.sections.dataProtection.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.privacy.sections.dataProtection.description}</p>
@@ -46,7 +46,7 @@ export default function PrivacyPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.privacy.sections.thirdParty.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.privacy.sections.thirdParty.description}</p>
@@ -58,7 +58,7 @@ export default function PrivacyPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.privacy.sections.dataRetention.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.privacy.sections.dataRetention.description}</p>
@@ -66,7 +66,7 @@ export default function PrivacyPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.privacy.sections.rights.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.privacy.sections.rights.description}</p>
@@ -79,7 +79,7 @@ export default function PrivacyPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.privacy.sections.contact.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.privacy.sections.contact.description}</p>

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -111,8 +111,8 @@ export default function SettingsClient() {
 
         return apiKeys.map((key) => (
             <div key={key.id} className="py-4 space-y-3">
-                <div className="flex items-center justify-between">
-                    <div>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
                         <p className="font-medium">{key.name}</p>
                         <p className="text-sm text-foreground/70">{t.settings.apiKeys.keyInfo.created.replace("{date}", new Date(key.created_at).toLocaleDateString())}</p>
                         {key.last_used ? (
@@ -121,7 +121,7 @@ export default function SettingsClient() {
                             <p className="text-sm text-foreground/70">{t.settings.apiKeys.keyInfo.neverUsed}</p>
                         )}
                     </div>
-                    <Button variant="destructive" onClick={() => setDialogs((prev) => ({ ...prev, delete: key }))}>
+                    <Button variant="destructive" onClick={() => setDialogs((prev) => ({ ...prev, delete: key }))} className="w-full sm:w-auto">
                         {t.settings.apiKeys.actions.delete}
                     </Button>
                 </div>
@@ -130,12 +130,12 @@ export default function SettingsClient() {
     }
 
     return (
-        <div className="container mx-auto px-4 py-16">
+        <div className="container mx-auto px-4 py-10 md:py-16">
             <div className="max-w-3xl mx-auto">
-                <h1 className="text-4xl font-bold mb-8">{t.settings.title}</h1>
+                <h1 className="text-3xl md:text-4xl font-bold mb-8">{t.settings.title}</h1>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
-                    <div className="flex items-center justify-between mb-6">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-6">
                         <h2 className="text-2xl font-bold">{t.settings.apiKeys.title}</h2>
                         <div className="text-sm text-foreground/70">{t.settings.apiKeys.usage.replace("{count}", apiKeys.length.toString())}</div>
                     </div>
@@ -192,7 +192,7 @@ export default function SettingsClient() {
                     <div className="py-4">
                         <Input value={newKeyName} onChange={(e) => setNewKeyName(e.target.value)} placeholder={t.settings.apiKeys.dialog.create.placeholder} className="w-full" />
                     </div>
-                    <DialogFooter>
+                    <DialogFooter className="flex-col sm:flex-row gap-2">
                         <Button variant="outline" onClick={() => setDialogs((prev) => ({ ...prev, create: false }))}>
                             {t.settings.apiKeys.actions.close}
                         </Button>
@@ -217,7 +217,7 @@ export default function SettingsClient() {
                             </div>
                         </DialogDescription>
                     </DialogHeader>
-                    <DialogFooter>
+                    <DialogFooter className="flex-col sm:flex-row gap-2">
                         <Button variant="outline" onClick={() => setDialogs((prev) => ({ ...prev, delete: null }))}>
                             {t.settings.apiKeys.actions.close}
                         </Button>

--- a/src/app/support/client.tsx
+++ b/src/app/support/client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslationsContext } from "@/context/translations-provider";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Coffee, AlertCircle } from "lucide-react";
 
@@ -8,45 +9,45 @@ export function SupportPageContent() {
     const { t } = useTranslationsContext();
 
     return (
-        <div className="container mx-auto px-4 py-16">
-            <div className="max-w-2xl mx-auto space-y-12">
-                <div className="text-center space-y-4">
-                    <h1 className="text-4xl font-bold">{t.support.title}</h1>
-                    <p className="text-lg text-muted-foreground">{t.support.description}</p>
+        <div className="container mx-auto px-4 py-8 md:py-10">
+            <div className="mx-auto flex max-w-xl flex-col gap-7">
+                <div className="text-center flex flex-col gap-3">
+                    <h1 className="text-3xl font-bold">{t.support.title}</h1>
+                    <p className="text-base leading-relaxed text-muted-foreground">{t.support.description}</p>
                 </div>
 
-                <div className="space-y-6">
-                    <h2 className="text-2xl font-bold">{t.support.benefits.title}</h2>
-                    <ul className="space-y-3">
+                <section className="flex flex-col gap-4 rounded-lg border border-border/60 bg-card p-4 sm:p-5">
+                    <h2 className="text-xl font-bold">{t.support.benefits.title}</h2>
+                    <ul className="flex flex-col gap-2">
                         {Object.values(t.support.benefits.items).map((benefit, index) => (
-                            <li key={index} className="flex items-center gap-3 text-foreground">
+                            <li key={index} className="flex items-center gap-2.5 text-sm text-foreground">
                                 <span>•</span>
                                 <span>{benefit}</span>
                             </li>
                         ))}
                     </ul>
-                </div>
+                </section>
 
-                <div className="space-y-6">
-                    <h2 className="text-2xl font-bold">{t.support.donate.title}</h2>
-                    <div className="rounded-lg border p-4 flex items-start gap-3 bg-yellow-500/10 border-yellow-500/50">
-                        <AlertCircle className="h-5 w-5 text-yellow-500 flex-shrink-0 mt-0.5" />
-                        <p className="text-sm">{t.support.donate.reminder}</p>
-                    </div>
+                <section className="flex flex-col gap-4">
+                    <h2 className="text-xl font-bold">{t.support.donate.title}</h2>
+                    <Alert className="border-yellow-500/50 bg-yellow-500/10 text-foreground [&>svg]:text-yellow-500">
+                        <AlertCircle />
+                        <AlertDescription>{t.support.donate.reminder}</AlertDescription>
+                    </Alert>
                     <a
                         href="https://www.buymeacoffee.com/yorunoken"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="block p-6 rounded-lg border bg-card transition-all duration-200 hover:shadow-md hover:border-primary/20"
+                        className="block rounded-lg border bg-card p-4 transition-all duration-200 hover:border-primary/20 hover:shadow-md sm:p-5"
                     >
-                        <div className="flex items-center gap-3 mb-4">
-                            <Coffee className="h-6 w-6 text-primary" />
-                            <span className="text-xl font-medium">{t.support.donate.button}</span>
+                        <div className="mb-3 flex items-center gap-3">
+                            <Coffee className="h-5 w-5 text-primary" />
+                            <span className="text-lg font-medium">{t.support.donate.button}</span>
                         </div>
-                        <p className="text-muted-foreground mb-6">{t.support.donate.description}</p>
+                        <p className="mb-4 text-sm leading-relaxed text-muted-foreground">{t.support.donate.description}</p>
                         <Button className="w-full bg-primary hover:bg-primary/90">{t.support.donate.button}</Button>
                     </a>
-                </div>
+                </section>
             </div>
         </div>
     );

--- a/src/app/tos/client.tsx
+++ b/src/app/tos/client.tsx
@@ -6,18 +6,18 @@ export default function TosPolicy() {
     const { t } = useTranslationsContext();
 
     return (
-        <div className="container mx-auto px-4 py-16 max-w-4xl">
-            <h1 className="text-4xl font-bold mb-8">{t.tos.title}</h1>
+        <div className="container mx-auto px-4 py-10 md:py-16 max-w-4xl">
+            <h1 className="text-3xl md:text-4xl font-bold mb-8">{t.tos.title}</h1>
 
             <div className="space-y-8">
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.tos.sections.acceptance.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.tos.sections.acceptance.description}</p>
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.tos.sections.eligibility.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.tos.sections.eligibility.description}</p>
@@ -29,7 +29,7 @@ export default function TosPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.tos.sections.content.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.tos.sections.content.description}</p>
@@ -41,7 +41,7 @@ export default function TosPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.tos.sections.termination.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.tos.sections.termination.description}</p>
@@ -52,7 +52,7 @@ export default function TosPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.tos.sections.disclaimer.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.tos.sections.disclaimer.description}</p>
@@ -60,14 +60,14 @@ export default function TosPolicy() {
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.tos.sections.changes.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.tos.sections.changes.description}</p>
                     </div>
                 </section>
 
-                <section className="bg-card rounded-xl p-8 border border-border/50">
+                <section className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
                     <h2 className="text-2xl font-semibold mb-4">{t.tos.sections.contact.title}</h2>
                     <div className="space-y-4 text-foreground/80">
                         <p>{t.tos.sections.contact.description}</p>

--- a/src/app/user/[banchoId]/NotFound.tsx
+++ b/src/app/user/[banchoId]/NotFound.tsx
@@ -11,10 +11,10 @@ export default function UserNotFound() {
     const { t } = useTranslationsContext();
 
     return (
-        <div className="container mx-auto px-4 py-16">
+        <div className="container mx-auto px-4 py-10 md:py-16">
             <div className="max-w-2xl mx-auto text-center">
-                <div className="bg-card rounded-xl p-8 border border-border/50">
-                    <h1 className="text-4xl font-bold mb-4">{t.user.notFound.title}</h1>
+                <div className="bg-card rounded-lg p-5 sm:p-8 border border-border/60">
+                    <h1 className="text-3xl md:text-4xl font-bold mb-4">{t.user.notFound.title}</h1>
 
                     <div className="space-y-4 mb-8">
                         <p className="text-foreground/70">{t.user.notFound.description}</p>

--- a/src/app/user/[banchoId]/client.tsx
+++ b/src/app/user/[banchoId]/client.tsx
@@ -87,7 +87,7 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
         }
 
         return (
-            <div className="container mx-auto px-4 py-16">
+            <div className="container mx-auto px-4 py-10 md:py-16">
                 <div className="flex items-center justify-center min-h-[400px]">
                     <div className="text-center">
                         <p className="text-destructive mb-4">Failed to load user data</p>
@@ -161,30 +161,33 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
     });
 
     return (
-        <div className="container mx-auto px-4 py-8 space-y-8 max-w-3xl">
-            <div className="flex items-center gap-6 bg-card p-8 rounded-xl">
-                <div className="relative h-32 w-32">
+        <div className="container mx-auto px-4 py-8 md:py-10 space-y-8 max-w-4xl">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-6 bg-card p-5 sm:p-8 rounded-lg border border-border/60">
+                <div className="relative h-28 w-28 sm:h-32 sm:w-32 shrink-0">
                     <Image src={avatar_url} alt={username} fill className="rounded-full object-cover" />
                 </div>
-                <div className="flex-1">
-                    <div className="flex items-center gap-4 mb-2">
-                        <Link href={`https://osu.ppy.sh/u/${banchoId}`} target="_blank" rel="noopener noreferrer" className="text-4xl font-bold hover:text-primary transition-colors">
+                <div className="flex-1 min-w-0">
+                    <div className="flex flex-col gap-3 mb-2 sm:flex-row sm:items-center sm:flex-wrap">
+                        <Link href={`https://osu.ppy.sh/u/${banchoId}`} target="_blank" rel="noopener noreferrer" className="text-3xl md:text-4xl font-bold hover:text-primary transition-colors break-words">
                             {username}
                         </Link>
-                        {user.badges.map((badge, index) => (
-                            <span
-                                key={index}
-                                className="px-2 py-1 rounded text-sm"
-                                style={{
-                                    backgroundColor: `${badge.color}10`,
-                                    color: badge.color,
-                                }}
-                            >
-                                {badge.name}
-                            </span>
-                        ))}
+                        <div className="flex flex-wrap gap-2">
+                            {user.badges.map((badge, index) => (
+                                <span
+                                    key={index}
+                                    className="px-2 py-1 rounded text-sm border"
+                                    style={{
+                                        backgroundColor: `${badge.color}10`,
+                                        color: badge.color,
+                                        borderColor: `${badge.color}30`,
+                                    }}
+                                >
+                                    {badge.name}
+                                </span>
+                            ))}
+                        </div>
                     </div>
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
                         <StatBox label={t.user.profile.stats.hiScore} value={Math.max(...(achievements?.map((a) => a.highest_score) ?? [0])).toLocaleString()} />
                         <StatBox label={t.user.profile.stats.totalGames} value={achievements?.reduce((sum, a) => sum + a.games_played, 0).toLocaleString() ?? "0"} />
                         <StatBox
@@ -196,29 +199,29 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
             </div>
 
             <div className="flex flex-col items-center gap-4">
-                <div className="flex justify-center gap-4">
+                <div className="flex w-full flex-wrap justify-center gap-3">
                     {gamemodes.map((mode) => (
                         <Link
                             key={mode}
                             href={`/user/${banchoId}?mode=${mode}&variant=${currentVariant}`}
-                            className={`px-4 py-2 rounded-lg capitalize ${currentMode === mode ? "bg-primary text-primary-foreground" : "bg-card hover:bg-primary/10"}`}
+                            className={`px-4 py-2 rounded-lg capitalize border border-border/60 ${currentMode === mode ? "bg-primary text-primary-foreground border-primary" : "bg-card hover:bg-primary/10"}`}
                         >
                             {t.leaderboard.filters.mode[mode]}
                         </Link>
                     ))}
                 </div>
 
-                <div className="flex justify-center gap-4">
+                <div className="flex w-full flex-col justify-center gap-3 sm:flex-row">
                     <Link
                         href={`/user/${banchoId}?mode=${currentMode}&variant=classic`}
-                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg ${currentVariant === "classic" ? "bg-primary text-primary-foreground" : "bg-card hover:bg-primary/10"}`}
+                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg border border-border/60 ${currentVariant === "classic" ? "bg-primary text-primary-foreground border-primary" : "bg-card hover:bg-primary/10"}`}
                     >
                         {t.leaderboard.filters.variant.classic}
                     </Link>
                     <Link
                         href={`/user/${banchoId}?mode=${currentMode}&variant=death`}
-                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg ${
-                            currentVariant === "death" ? "bg-destructive text-destructive-foreground hover:bg-destructive/90" : "bg-card hover:bg-destructive/10 hover:text-destructive"
+                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg border border-border/60 ${
+                            currentVariant === "death" ? "bg-destructive text-destructive-foreground hover:bg-destructive/90 border-destructive" : "bg-card hover:bg-destructive/10 hover:text-destructive"
                         }`}
                     >
                         {t.leaderboard.filters.variant.death}
@@ -230,7 +233,7 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
                 <h2 className="text-2xl font-bold mb-6 text-center capitalize">
                     {t.user.profile.gameStats.title} ({currentMode})
                 </h2>
-                <div className="bg-card p-6 rounded-xl border border-border/50">
+                <div className="bg-card p-5 sm:p-6 rounded-lg border border-border/60">
                     {gameStats[currentMode].games_played > 0 ? (
                         <div className="space-y-4">
                             {currentVariant === "classic" && (
@@ -257,10 +260,10 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
                 <h2 className="text-2xl font-bold mb-6 text-center capitalize">
                     {t.user.profile.topGames.title} ({currentMode})
                 </h2>
-                <div className="bg-card p-6 rounded-xl border border-border/50">
+                <div className="bg-card p-5 sm:p-6 rounded-lg border border-border/60">
                     <div className="space-y-4">
                         {topPlaysByMode[currentMode]?.slice(0, 5).map((game, index) => (
-                            <div key={index} className="flex justify-between items-center">
+                            <div key={index} className="flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center">
                                 <div className="flex items-center gap-2">
                                     <span className="text-foreground/70">#{index + 1}</span>
                                     {currentVariant === "classic" ? (
@@ -283,16 +286,16 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
             {/* Recent Games */}
             <section>
                 <h2 className="text-2xl font-bold mb-6 text-center">{t.user.profile.recentGames.title}</h2>
-                <div className="bg-card rounded-xl border border-border/50">
+                <div className="bg-card rounded-lg border border-border/60">
                     {userGames.length > 0 ? (
                         <div className="divide-y divide-border/50">
                             {userGames.map((game, index) => (
-                                <div key={index} className="p-4 flex justify-between items-center">
+                                <div key={index} className="p-4 flex flex-col gap-2 sm:flex-row sm:justify-between sm:items-center">
                                     <div>
                                         <span className="font-medium capitalize">{game.game_mode} Mode</span>
                                         <span className="text-foreground/70 ml-4">{new Date(game.ended_at).toLocaleDateString()}</span>
                                     </div>
-                                    <div className="space-x-4">
+                                    <div className="flex flex-wrap gap-x-4 gap-y-1">
                                         {currentVariant === "classic" && <span className="font-semibold">{t.user.profile.topGames.points.replace("{points}", game.points.toLocaleString())}</span>}
                                         <span className="font-semibold">{t.user.profile.topGames.streak.replace("{count}", game.streak.toString())}</span>
                                     </div>
@@ -312,16 +315,16 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
 
 function StatItem({ label, value }: { label: string; value: string }) {
     return (
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-center gap-4">
             <span className="text-foreground/70">{label}</span>
-            <span className="font-medium">{value}</span>
+            <span className="font-medium text-right">{value}</span>
         </div>
     );
 }
 
 function StatBox({ label, value }: { label: string; value: string }) {
     return (
-        <div className="bg-background/50 p-3 rounded-lg">
+        <div className="bg-background/50 p-3 rounded-lg border border-border/50">
             <div className="text-sm text-foreground/70">{label}</div>
             <div className="text-lg font-semibold">{value}</div>
         </div>
@@ -332,8 +335,8 @@ function UserProfileSkeleton({ currentMode, currentVariant, banchoId }: { curren
     const { t } = useTranslationsContext();
 
     return (
-        <div className="container mx-auto px-4 py-8 space-y-8 max-w-3xl">
-            <div className="flex items-center gap-6 bg-card p-8 rounded-xl">
+        <div className="container mx-auto px-4 py-8 md:py-10 space-y-8 max-w-4xl">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-6 bg-card p-5 sm:p-8 rounded-lg border border-border/60">
                 <div className="relative h-32 w-32">
                     <div className="h-32 w-32 bg-muted rounded-full animate-pulse" />
                 </div>
@@ -341,7 +344,7 @@ function UserProfileSkeleton({ currentMode, currentVariant, banchoId }: { curren
                     <div className="flex items-center gap-4 mb-2">
                         <div className="h-10 w-48 bg-muted rounded animate-pulse" />
                     </div>
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
                         {[...Array(3)].map((_, i) => (
                             <div key={i} className="bg-background/50 p-3 rounded-lg">
                                 <div className="h-4 w-16 bg-muted rounded animate-pulse mb-2" />
@@ -358,7 +361,7 @@ function UserProfileSkeleton({ currentMode, currentVariant, banchoId }: { curren
                         <Link
                             key={mode}
                             href={`/user/${banchoId}?mode=${mode}&variant=${currentVariant}`}
-                            className={`px-4 py-2 rounded-lg capitalize ${currentMode === mode ? "bg-primary text-primary-foreground" : "bg-card hover:bg-primary/10"}`}
+                            className={`px-4 py-2 rounded-lg capitalize border border-border/60 ${currentMode === mode ? "bg-primary text-primary-foreground border-primary" : "bg-card hover:bg-primary/10"}`}
                         >
                             {t.leaderboard.filters.mode[mode]}
                         </Link>
@@ -368,14 +371,14 @@ function UserProfileSkeleton({ currentMode, currentVariant, banchoId }: { curren
                 <div className="flex justify-center gap-4">
                     <Link
                         href={`/user/${banchoId}?mode=${currentMode}&variant=classic`}
-                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg ${currentVariant === "classic" ? "bg-primary text-primary-foreground" : "bg-card hover:bg-primary/10"}`}
+                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg border border-border/60 ${currentVariant === "classic" ? "bg-primary text-primary-foreground border-primary" : "bg-card hover:bg-primary/10"}`}
                     >
                         {t.leaderboard.filters.variant.classic}
                     </Link>
                     <Link
                         href={`/user/${banchoId}?mode=${currentMode}&variant=death`}
-                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg ${
-                            currentVariant === "death" ? "bg-destructive text-destructive-foreground hover:bg-destructive/90" : "bg-card hover:bg-destructive/10 hover:text-destructive"
+                        className={`min-w-[120px] text-center px-4 py-2 rounded-lg border border-border/60 ${
+                            currentVariant === "death" ? "bg-destructive text-destructive-foreground hover:bg-destructive/90 border-destructive" : "bg-card hover:bg-destructive/10 hover:text-destructive"
                         }`}
                     >
                         {t.leaderboard.filters.variant.death}
@@ -387,7 +390,7 @@ function UserProfileSkeleton({ currentMode, currentVariant, banchoId }: { curren
                 <h2 className="text-2xl font-bold mb-6 text-center capitalize">
                     {t.user.profile.gameStats.title} ({currentMode})
                 </h2>
-                <div className="bg-card p-6 rounded-xl border border-border/50">
+                <div className="bg-card p-5 sm:p-6 rounded-lg border border-border/60">
                     <div className="space-y-4">
                         {[...Array(5)].map((_, i) => (
                             <div key={i} className="flex justify-between items-center">
@@ -403,7 +406,7 @@ function UserProfileSkeleton({ currentMode, currentVariant, banchoId }: { curren
                 <h2 className="text-2xl font-bold mb-6 text-center capitalize">
                     {t.user.profile.topGames.title} ({currentMode})
                 </h2>
-                <div className="bg-card p-6 rounded-xl border border-border/50">
+                <div className="bg-card p-5 sm:p-6 rounded-lg border border-border/60">
                     <div className="space-y-4">
                         {[...Array(5)].map((_, i) => (
                             <div key={i} className="flex justify-between items-center">
@@ -420,7 +423,7 @@ function UserProfileSkeleton({ currentMode, currentVariant, banchoId }: { curren
 
             <section>
                 <h2 className="text-2xl font-bold mb-6 text-center">{t.user.profile.recentGames.title}</h2>
-                <div className="bg-card rounded-xl border border-border/50">
+                <div className="bg-card rounded-lg border border-border/60">
                     <div className="divide-y divide-border/50">
                         {[...Array(5)].map((_, i) => (
                             <div key={i} className="p-4 flex justify-between items-center">

--- a/src/components/Ads.tsx
+++ b/src/components/Ads.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 import { Translations, useTranslations } from "@/hooks/use-translations";
 
 interface Promo {
@@ -79,19 +78,17 @@ export function AdSlider() {
 
     return (
         <div className="max-w-md mx-auto bg-transparent border border-dashed border-border rounded-lg my-8">
-            <AnimatePresence mode="wait">
-                <motion.div key={currentIndex} initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -20 }} transition={{ duration: 0.3 }} className="h-full">
-                    <a href={promos[currentIndex].link} target="_blank" rel="noopener noreferrer" className="block h-full p-4 hover:opacity-80 transition-opacity">
-                        <div className="flex flex-col items-center justify-center text-center gap-3 h-full">
-                            {promos[currentIndex].icon && <span className="text-2xl">{promos[currentIndex].icon}</span>}
-                            <div>
-                                <h3 className="font-medium">{promos[currentIndex].title}</h3>
-                                <p className="text-sm text-muted-foreground">{promos[currentIndex].message}</p>
-                            </div>
+            <div className="h-full">
+                <a href={promos[currentIndex].link} target="_blank" rel="noopener noreferrer" className="block h-full p-4 hover:opacity-80 transition-opacity">
+                    <div className="flex flex-col items-center justify-center text-center gap-3 h-full">
+                        {promos[currentIndex].icon && <span className="text-2xl">{promos[currentIndex].icon}</span>}
+                        <div>
+                            <h3 className="font-medium">{promos[currentIndex].title}</h3>
+                            <p className="text-sm text-muted-foreground">{promos[currentIndex].message}</p>
                         </div>
-                    </a>
-                </motion.div>
-            </AnimatePresence>
+                    </div>
+                </a>
+            </div>
         </div>
     );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,14 +34,14 @@ export default function Header() {
         <header className="bg-background/95 backdrop-blur-md border-b sticky top-0 z-50 shadow-sm">
             <div className="container mx-auto px-4 py-3 flex justify-between items-center">
                 <div className="flex items-center space-x-8">
-                    <Link href="/" className="text-2xl font-bold text-primary hover:text-primary/80 transition-colors">
+                    <Link href="/" className="text-2xl font-bold text-primary hover:text-primary/80 transition-[color,opacity] duration-150 ease-[var(--ease-out-smooth)]">
                         osu!guessr
                     </Link>
                     <nav className="hidden md:block">
                         <ul className="flex space-x-8 items-center">
                             {NAV_ITEMS.map((item) => (
                                 <li key={item}>
-                                    <Link href={`/${item}`} className="text-foreground/80 hover:text-primary transition-colors duration-200 font-medium">
+                                    <Link href={`/${item}`} className="subtle-link text-foreground/80 hover:text-primary transition-colors duration-200 font-medium">
                                         {getNavLabel(item)}
                                     </Link>
                                 </li>
@@ -59,19 +59,19 @@ export default function Header() {
                         <SupportPageLink />
                     </div>
 
-                    <Button variant="ghost" className="md:hidden" onClick={() => setIsMenuOpen(!isMenuOpen)}>
+                    <Button variant="ghost" className="md:hidden" onClick={() => setIsMenuOpen(!isMenuOpen)} aria-expanded={isMenuOpen}>
                         <Menu className="h-6 w-6" />
                     </Button>
 
                     {session ? (
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                                <Button variant="ghost" className="relative h-10 w-10 rounded-full p-0">
+                                <Button variant="ghost" className="relative h-10 w-10 rounded-full p-0 active:!transform-none">
                                     <Image src={session.user?.image || "/default-avatar.png"} alt="Avatar" className="rounded-full" fill style={{ objectFit: "cover" }} />
                                 </Button>
                             </DropdownMenuTrigger>
 
-                            <DropdownMenuContent align="end" className="w-56">
+                            <DropdownMenuContent align="end" className="w-56 duration-0 data-[state=closed]:!animate-none data-[state=open]:!animate-none">
                                 <DropdownMenuItem className="cursor-pointer" asChild>
                                     <Link href={`/user/${session.user.banchoId}`} className="flex items-center">
                                         <div className="relative h-8 w-8 rounded-full mr-2">
@@ -103,8 +103,8 @@ export default function Header() {
 
                 <nav
                     className={`${
-                        isMenuOpen ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0"
-                    } md:hidden overflow-hidden transition-all duration-200 ease-in-out absolute top-full left-0 w-full bg-background shadow-md`}
+                        isMenuOpen ? "max-h-[500px] opacity-100 translate-y-0" : "max-h-0 opacity-0 -translate-y-2"
+                    } md:hidden overflow-hidden transition-all duration-200 ease-[var(--ease-out-smooth)] absolute top-full left-0 w-full bg-background shadow-md`}
                 >
                     <ul className="flex flex-col space-y-4 items-center py-4">
                         <li className="w-full px-4">

--- a/src/components/UserSearch.tsx
+++ b/src/components/UserSearch.tsx
@@ -87,14 +87,16 @@ export default function UserSearch() {
 
                 <div className="max-h-[60vh] overflow-y-auto">
                     {isSearching ? (
-                        <div className="p-8 text-center text-foreground/70">{t.user.search.searching}</div>
+                        <div className="p-8 text-center text-foreground/70">
+                            <span className="soft-loading-dot inline-block">{t.user.search.searching}</span>
+                        </div>
                     ) : results.length > 0 ? (
                         <div className="py-2">
                             {results.map((user) => (
                                 <Link
                                     key={user.bancho_id.toString()}
                                     href={`/user/${user.bancho_id.toString()}`}
-                                    className="w-full flex items-center gap-3 px-4 py-3 hover:bg-accent/50 transition-colors"
+                                    className="w-full flex items-center gap-3 px-4 py-3 hover:bg-accent/50 transition-[background-color,color] duration-150 ease-[var(--ease-out-smooth)]"
                                     onClick={() => handleSelect()}
                                 >
                                     <Image src={user.avatar_url || "/placeholder.svg"} alt={user.username} width={40} height={40} className="rounded-full" />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,19 +5,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "press-feedback inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 disabled:transform-none [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90 hover:shadow-[0_0_0_1px_hsl(var(--primary)/0.18),0_14px_34px_-22px_hsl(var(--primary)/0.9)]",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-[0_0_0_1px_hsl(var(--destructive)/0.18),0_14px_34px_-22px_hsl(var(--destructive)/0.85)]",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background shadow-sm hover:border-primary/45 hover:bg-accent/90 hover:text-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--primary)/0.12)]",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:shadow-[0_0_0_1px_hsl(var(--foreground)/0.08)]",
+        ghost: "hover:bg-accent hover:text-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--primary)/0.1)]",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 duration-200 ease-[var(--ease-out-smooth)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 ease-[var(--ease-out-smooth)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[49%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[49%] sm:rounded-lg",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="press-feedback absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 hover:bg-accent/60 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-[background-color,color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] origin-[--radix-dropdown-menu-content-transform-origin] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg duration-150 ease-[var(--ease-out-smooth)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
       className
     )}
     {...props}
@@ -66,7 +66,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "origin-[--radix-dropdown-menu-content-transform-origin] duration-150 ease-[var(--ease-out-smooth)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
         className
       )}
       {...props}
@@ -84,7 +84,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-[background-color,color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -100,7 +100,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-[background-color,color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-[background-color,color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-[border-color,box-shadow,background-color,opacity] duration-150 ease-[var(--ease-out-smooth)] file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-primary/55 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -28,12 +28,12 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary shadow transition-[box-shadow,background-color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)]",
         className
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <RadioGroupPrimitive.Indicator className="motion-scale-in flex items-center justify-center">
         <Circle className="h-3.5 w-3.5 fill-primary" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background transition-[border-color,box-shadow,background-color,opacity] duration-150 ease-[var(--ease-out-smooth)] data-[placeholder]:text-muted-foreground focus:border-primary/55 focus:outline-none focus:ring-1 focus:ring-ring focus:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)] disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 [&>svg]:transition-transform [&>svg]:duration-150 [&>svg]:ease-[var(--ease-out-smooth)] data-[state=open]:[&>svg]:rotate-180",
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] origin-[--radix-select-content-transform-origin] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md duration-150 ease-[var(--ease-out-smooth)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none transition-[background-color,color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-[background-color,box-shadow,opacity] duration-150 ease-[var(--ease-out-smooth)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input data-[state=checked]:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)]",
       className
     )}
     {...props}
@@ -19,7 +19,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform duration-150 ease-[var(--ease-press)] data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
       )}
     />
   </SwitchPrimitives.Root>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm transition-[border-color,box-shadow,background-color,opacity] duration-150 ease-[var(--ease-out-smooth)] placeholder:text-muted-foreground focus-visible:border-primary/55 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -25,7 +25,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all duration-200 ease-[var(--ease-out-smooth)] data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {
@@ -62,7 +62,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      "press-feedback inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
       className
     )}
     {...props}


### PR DESCRIPTION
- tighten oversized card surfaces across the home, support, profile, informational, game, and admin pages
- replace Framer Motion usage with shared CSS motion utilities and smoother shadcn primitive transitions
- improve the game pre-menu and in-game layouts so mode/help sections feel less jarring while staying compact
- defer home page data sections with Suspense and fetch only recent announcements for the home preview

Closes #29