### PR TITLE
Preserve active games across deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,12 +8,9 @@ node_modules
 build
 dist
 
-# Environment variables
+# Environment variables. `.env` is the local app file; variants stay ignored too.
 .env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*.local
 
 # Git
 .git

--- a/.env.template
+++ b/.env.template
@@ -49,6 +49,11 @@ NEXTAUTH_URL="http://localhost:3000"
 # openssl rand -base64 32
 AUTH_SECRET=""
 
+# Stable key used by Next.js Server Actions across production Docker builds.
+# Generate one with:
+# openssl rand -base64 32
+NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=""
+
 # -----------------------------------------------------------------------------
 # Reports
 # -----------------------------------------------------------------------------
@@ -68,7 +73,7 @@ DISCORD_WEBHOOK=""
 #
 # Docker Compose example:
 # mysql://root:password@mariadb_shared:3306/osu_guessr
-DATABASE_URL="mysql://root:password@127.0.0.1:3306/osu_guessr"
+DATABASE_URL=""
 
 # Used only when DATABASE_URL is empty.
 # The fallback connection is:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,12 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
 
+      - name: Verify Server Actions key
+        if: github.event_name != 'pull_request'
+        env:
+          NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
+        run: test -n "$NEXT_SERVER_ACTIONS_ENCRYPTION_KEY"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -50,5 +56,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          secrets: |
+            next_server_actions_encryption_key=${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 FROM oven/bun:1-alpine AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
@@ -12,16 +14,24 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+ARG GIT_SHA=local
 ENV IS_DOCKER_BUILD=true
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_DEPLOYMENT_ID=$GIT_SHA
 
-RUN bun run build
+RUN --mount=type=secret,id=next_server_actions_encryption_key,required=false \
+    if [ -s /run/secrets/next_server_actions_encryption_key ]; then \
+        export NEXT_SERVER_ACTIONS_ENCRYPTION_KEY="$(cat /run/secrets/next_server_actions_encryption_key)"; \
+    fi; \
+    bun run build
 
 FROM node:20-alpine AS runner
 WORKDIR /app
 
+ARG GIT_SHA=local
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV NEXT_DEPLOYMENT_ID=$GIT_SHA
 ENV PORT=3000 
 
 RUN addgroup --system --gid 1001 nodejs
@@ -34,5 +44,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 USER nextjs
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:3000/api/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"
 
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Want to add your language? Follow the guide and submit a PR!
 3. **Environment Setup**
 
     ```bash
-    cp .env.template .env.local
+    cp .env.template .env
     ```
 
     Fill in your environment variables:

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
+const deploymentId = process.env.NEXT_DEPLOYMENT_ID || process.env.VERCEL_GIT_COMMIT_SHA;
+
 const nextConfig: NextConfig = {
     output: "standalone",
+    deploymentId,
     images: { remotePatterns: [{ hostname: "a.ppy.sh" }, { hostname: "assets.ppy.sh" }] },
     reactStrictMode: false,
     experimental: {

--- a/src/actions/game-server.ts
+++ b/src/actions/game-server.ts
@@ -11,6 +11,13 @@ import { getMediaData } from "./media";
 import { checkGuess, GuessDifficulty } from "@/lib/guess-checker";
 
 const GRACE_PERIOD = 1;
+const SESSION_LOCK_TTL_MS = 5000;
+const RELEASE_SESSION_LOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+end
+return 0
+`;
 
 const gameSchema = z.object({
     sessionId: z.string().uuid(),
@@ -25,20 +32,34 @@ const gameSchema = z.object({
 // const rateLimits = new Map<string, number>();
 // const RATE_LIMIT_WINDOW = 1000;
 
-const activeSessions = new Map<string, boolean>();
+type SessionLock = {
+    key: string;
+    token: string;
+};
 
-async function acquireSessionLock(sessionId: string, timeoutMs: number = 5000): Promise<boolean> {
-    if (activeSessions.get(sessionId)) {
-        return false;
+async function acquireSessionLock(sessionId: string, timeoutMs: number = SESSION_LOCK_TTL_MS): Promise<SessionLock | null> {
+    const key = `game_session_lock:${sessionId}`;
+    const token = crypto.randomUUID();
+    const result = await redisClient.set(key, token, {
+        condition: "NX",
+        expiration: {
+            type: "PX",
+            value: timeoutMs,
+        },
+    });
+
+    return result === "OK" ? { key, token } : null;
+}
+
+async function releaseSessionLock(lock: SessionLock): Promise<void> {
+    try {
+        await redisClient.eval(RELEASE_SESSION_LOCK_SCRIPT, {
+            keys: [lock.key],
+            arguments: [lock.token],
+        });
+    } catch (error) {
+        console.error("Failed to release game session lock:", error);
     }
-
-    activeSessions.set(sessionId, true);
-
-    setTimeout(() => {
-        activeSessions.delete(sessionId);
-    }, timeoutMs);
-
-    return true;
 }
 
 async function validateGameSession(sessionId: string, userId: number): Promise<DatabaseGameSession> {
@@ -135,8 +156,9 @@ export async function startGameAction(gameMode: GameMode, variant: GameVariant =
 export async function submitGuessAction(sessionId: string, guess?: string | null): Promise<GameState> {
     const authSession = await getAuthSession();
     const validated = gameSchema.parse({ sessionId, guess });
+    const lock = await acquireSessionLock(validated.sessionId);
 
-    if (!(await acquireSessionLock(validated.sessionId))) {
+    if (!lock) {
         throw new Error("Action in progress, please wait");
     }
 
@@ -445,7 +467,7 @@ export async function submitGuessAction(sessionId: string, guess?: string | null
     } catch (error) {
         throw error;
     } finally {
-        activeSessions.delete(validated.sessionId);
+        await releaseSessionLock(lock);
     }
 }
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+export function GET() {
+    return NextResponse.json({
+        ok: true,
+        deploymentId: process.env.NEXT_DEPLOYMENT_ID || null,
+    });
+}

--- a/src/app/games/shared/pages/GameScreen.tsx
+++ b/src/app/games/shared/pages/GameScreen.tsx
@@ -79,7 +79,11 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                 }
             );
 
-            await gameClient.current.startGame();
+            const resumed = await gameClient.current.resumeStoredGame();
+            if (!resumed) {
+                await gameClient.current.startGame();
+            }
+
             setCountdown(AUTO_ADVANCE_DELAY_MS / 1000);
         } catch (error) {
             console.error("Failed to restart game:", error);
@@ -92,7 +96,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
         handleStartGame();
 
         return () => {
-            gameClient.current?.endGame().catch(console.error);
+            gameClient.current?.dispose();
         };
     }, [handleStartGame]);
 

--- a/src/lib/game/client.ts
+++ b/src/lib/game/client.ts
@@ -12,6 +12,10 @@ const DEFAULT_CONFIG: GameClientConfig = {
     recoveryMode: "auto",
 };
 
+const SERVER_ACTION_DEPLOYMENT_MISMATCH = "Failed to find Server Action";
+const SERVER_ACTION_DEPLOYMENT_VERSION_HINT = "older or newer deployment";
+const ACTION_RELOAD_ATTEMPTED_KEY = "osu-guessr:action-reload-attempted";
+
 export class GameClient {
     private session: GameSession | null = null;
     private events: GameClientEvents;
@@ -30,6 +34,43 @@ export class GameClient {
 
     private isSupportedGameMode(mode: GameMode): mode is GameMode {
         return mode === GameMode.Audio || mode === GameMode.Background || mode === GameMode.Skin;
+    }
+
+    private get storageKey(): string {
+        return `osu-guessr:game-session:${this.gameMode}:${this.gameVariant}`;
+    }
+
+    private getStorage(): Storage | null {
+        if (typeof window === "undefined") return null;
+        return window.sessionStorage;
+    }
+
+    private persistSessionId(sessionId: string): void {
+        try {
+            this.getStorage()?.setItem(this.storageKey, sessionId);
+        } catch (error) {
+            console.warn("Failed to persist game session id:", error);
+        }
+    }
+
+    private clearStoredSessionId(): void {
+        try {
+            this.getStorage()?.removeItem(this.storageKey);
+        } catch (error) {
+            console.warn("Failed to clear stored game session id:", error);
+        }
+    }
+
+    private shouldReloadForServerActionMismatch(error: Error): boolean {
+        return error.message.includes(SERVER_ACTION_DEPLOYMENT_MISMATCH) || error.message.includes(SERVER_ACTION_DEPLOYMENT_VERSION_HINT);
+    }
+
+    private reloadForServerActionMismatch(): void {
+        const storage = this.getStorage();
+        if (!storage || storage.getItem(ACTION_RELOAD_ATTEMPTED_KEY) === "true") return;
+
+        storage.setItem(ACTION_RELOAD_ATTEMPTED_KEY, "true");
+        window.location.reload();
     }
 
     getStatus(): GameClientStatus {
@@ -58,6 +99,11 @@ export class GameClient {
             } catch (error) {
                 const gameError = handleGameError(error);
                 lastError = gameError;
+
+                if (this.shouldReloadForServerActionMismatch(gameError)) {
+                    this.reloadForServerActionMismatch();
+                    throw gameError;
+                }
 
                 this.events.onError?.(gameError);
 
@@ -95,6 +141,7 @@ export class GameClient {
                 retryCount: 0,
             };
 
+            this.persistSessionId(initialState.sessionId);
             this.setStatus("active");
             this.startTimer();
             console.log(`[Game Client]: Started ${this.gameMode} Game (${this.gameVariant} mode)`);
@@ -102,6 +149,49 @@ export class GameClient {
             this.setStatus("error");
             console.error("Failed to start game:", error);
             throw error;
+        }
+    }
+
+    async resumeStoredGame(): Promise<boolean> {
+        const sessionId = this.getStorage()?.getItem(this.storageKey);
+        if (!sessionId) return false;
+
+        this.setStatus("starting");
+
+        try {
+            const restoredState = await this.executeWithRetry(() => getGameStateAction(sessionId), "resumeStoredGame");
+
+            if (restoredState.gameStatus !== "active") {
+                this.clearStoredSessionId();
+                return false;
+            }
+
+            this.session = {
+                id: restoredState.sessionId,
+                state: restoredState,
+                timer: null,
+                isActive: true,
+                lastActivity: new Date(),
+                retryCount: 0,
+            };
+
+            this.getStorage()?.removeItem(ACTION_RELOAD_ATTEMPTED_KEY);
+            this.persistSessionId(restoredState.sessionId);
+            this.setStatus("active");
+            this.events.onRecovery?.();
+            this.events.onStateUpdate(restoredState);
+
+            if (!restoredState.currentBeatmap.revealed) {
+                this.startTimer();
+            }
+
+            console.log("[Game Client]: Resumed stored game session");
+            return true;
+        } catch (error) {
+            this.setStatus("error");
+            this.clearStoredSessionId();
+            console.error("Failed to resume stored game:", error);
+            return false;
         }
     }
 
@@ -135,7 +225,7 @@ export class GameClient {
         this.stopTimer();
         try {
             soundManager.play("timeout");
-            const newState = await submitGuessAction(this.session.id, "");
+            const newState = await this.executeWithRetry(() => submitGuessAction(this.session!.id, ""), "handleTimeout");
             this.updateState(newState);
             console.log("[Game Client]: Round timed out");
         } catch (error) {
@@ -223,6 +313,15 @@ export class GameClient {
         this.session.state = newState;
         this.session.lastActivity = new Date();
         this.events.onStateUpdate(newState);
+
+        if (newState.gameStatus === "finished") {
+            this.stopTimer();
+            this.session.isActive = false;
+            this.clearStoredSessionId();
+            this.setStatus("ended");
+        } else {
+            this.persistSessionId(newState.sessionId);
+        }
     }
 
     async endGame(): Promise<void> {
@@ -243,6 +342,15 @@ export class GameClient {
         }
     }
 
+    dispose(): void {
+        this.stopTimer();
+        if (this.session) {
+            this.session.isActive = false;
+        }
+        this.session = null;
+        this.setStatus("idle");
+    }
+
     async getSuggestions(query: string): Promise<string[]> {
         if (!this.session?.isActive || this.session.state.currentBeatmap.revealed) {
             return [];
@@ -260,6 +368,7 @@ export class GameClient {
     private cleanup(): void {
         this.stopTimer();
         this.session = null;
+        this.clearStoredSessionId();
         this.setStatus("idle");
     }
 }


### PR DESCRIPTION
Preserves active Redis-backed game sessions when a production Docker deployment replaces the running Next.js build.

Changes:
- Keep Server Action encryption stable across Docker builds by passing `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` as a BuildKit secret.
- Add a commit-based Next.js `deploymentId` and expose `/api/health` for container health checks.
- Persist active game session IDs in `sessionStorage`, reload on stale Server Action deployment errors, and resume with `getGameStateAction` after the new bundle loads.
- Stop ending games from `GameScreen` unmount cleanup; unmount now only disposes local timers/resources.
- Replace the process-local active session map with a Redis lock so overlapping deployments or multiple app instances serialize game actions.
- Refresh `.env.template` with the documented env layout and safe placeholders.

Root cause: deployed browsers can hold Server Action IDs from an older build while the replacement container only knows the new IDs, and the old unmount cleanup could end the Redis session during recovery.

Closes #32