### PR TITLE
fix(ui): handle error states and profile edge cases

### DIFF
--- a/src/actions/user-server.ts
+++ b/src/actions/user-server.ts
@@ -6,6 +6,7 @@ import { authenticatedAction } from "./server";
 import { OWNER_ID } from "@/lib";
 import { GameVariant } from "@/app/games/config";
 import { Game, GameMode, HighestStats, TopPlayer, User, UserAchievement, UserWithStats, UserRanks, UserBadge } from "./types";
+import { hasPlayedGame } from "@/lib/user-stats";
 
 export type { UserRanks };
 
@@ -148,8 +149,8 @@ export async function getUserByIdAction(banchoId: number): Promise<UserWithStats
         )) as [{ rank: number }];
 
         modeRanks[mode] = {
-            classic: classicRank[0].rank + 1,
-            death: deathRank[0].rank + 1,
+            classic: hasPlayedGame(achievements, "classic", mode) ? classicRank[0].rank + 1 : undefined,
+            death: hasPlayedGame(achievements, "death", mode) ? deathRank[0].rank + 1 : undefined,
         };
     }
 
@@ -159,8 +160,8 @@ export async function getUserByIdAction(banchoId: number): Promise<UserWithStats
         achievements,
         ranks: {
             globalRank: {
-                classic: globalClassicRankResult[0].globalRank + 1,
-                death: globalDeathRankResult[0].globalRank + 1,
+                classic: hasPlayedGame(achievements, "classic") ? globalClassicRankResult[0].globalRank + 1 : undefined,
+                death: hasPlayedGame(achievements, "death") ? globalDeathRankResult[0].globalRank + 1 : undefined,
             },
             modeRanks,
         },

--- a/src/app/games/audio/components/GameAudio.tsx
+++ b/src/app/games/audio/components/GameAudio.tsx
@@ -5,10 +5,12 @@ import { useRef, useEffect, useState } from "react";
 import { ResultMessage } from "../../shared/components/Result";
 import { useTranslationsContext } from "@/context/translations-provider";
 import { GameMediaProps } from "@/lib/game/interfaces";
+import { Button } from "@/components/ui/button";
 
 export default function GameAudio({ mediaUrl, isRevealed, result, songInfo, onVolumeChange, initialVolume }: GameMediaProps) {
     const audioRef = useRef<HTMLAudioElement>(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [mediaError, setMediaError] = useState<string | null>(null);
     const { t } = useTranslationsContext();
 
     useEffect(() => {
@@ -16,30 +18,51 @@ export default function GameAudio({ mediaUrl, isRevealed, result, songInfo, onVo
             audioRef.current.pause();
             audioRef.current.currentTime = 0;
             setIsLoading(true);
+            setMediaError(null);
 
             const handleCanPlay = () => {
+                window.clearTimeout(loadTimeout);
                 setIsLoading(false);
                 if (!isRevealed) {
                     const playPromise = audioRef.current!.play();
                     if (playPromise !== undefined) {
-                        playPromise.catch((error) => {
+                        playPromise.catch((error: unknown) => {
                             console.log("Audio playback failed:", error);
+                            setIsLoading(false);
+                            setMediaError(t.game.audio.loadFailed);
                         });
                     }
                 }
             };
 
+            const handleError = () => {
+                window.clearTimeout(loadTimeout);
+                setIsLoading(false);
+                setMediaError(t.game.audio.loadFailed);
+            };
+
+            const loadTimeout = window.setTimeout(handleError, 15000);
+
             const audio = audioRef.current; // Copy ref to variable
             audio.addEventListener("canplay", handleCanPlay);
+            audio.addEventListener("error", handleError);
             audio.load();
 
             return () => {
                 audio.removeEventListener("canplay", handleCanPlay);
+                audio.removeEventListener("error", handleError);
+                window.clearTimeout(loadTimeout);
                 audio.pause();
                 audio.currentTime = 0;
             };
         }
-    }, [mediaUrl, isRevealed]);
+    }, [mediaUrl, isRevealed, t.game.audio.loadFailed]);
+
+    const retryAudio = () => {
+        setMediaError(null);
+        setIsLoading(true);
+        audioRef.current?.load();
+    };
 
     useEffect(() => {
         if (audioRef.current && initialVolume !== undefined) {
@@ -76,7 +99,15 @@ export default function GameAudio({ mediaUrl, isRevealed, result, songInfo, onVo
                         <Loader2 className="h-6 w-6 animate-spin" />
                     </div>
                 )}
-                <audio ref={audioRef} controls className={`w-full mb-4 ${isLoading ? "hidden" : "block"}`}>
+                {mediaError && (
+                    <div role="alert" className="mb-4 rounded-md border border-destructive/30 bg-destructive/10 p-4 text-center">
+                        <p className="mb-3 text-sm text-destructive">{mediaError}</p>
+                        <Button type="button" size="sm" variant="outline" onClick={retryAudio}>
+                            {t.game.audio.retry}
+                        </Button>
+                    </div>
+                )}
+                <audio ref={audioRef} controls className={`w-full mb-4 ${isLoading || mediaError ? "hidden" : "block"}`}>
                     <source src={mediaUrl} type="audio/mp3" />
                     {t.game.audio.browserNotSupported}
                 </audio>

--- a/src/app/games/shared/pages/GameScreen.tsx
+++ b/src/app/games/shared/pages/GameScreen.tsx
@@ -14,6 +14,9 @@ import GameHeader from "../components/Header";
 import { ReportDialog } from "@/components/ReportDialog";
 import { AdSlider } from "@/components/Ads";
 import { useTranslationsContext } from "@/context/translations-provider";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+import { getDeathEndReason } from "@/lib/game/result";
 
 interface GameScreenProps {
     onExit(): void;
@@ -47,6 +50,8 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
     const [countdown, setCountdown] = useState<number>(AUTO_ADVANCE_DELAY_MS / 1000);
     const [showStats, setShowStats] = useState(false);
     const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
+    const [startupError, setStartupError] = useState<string | null>(null);
+    const [actionError, setActionError] = useState<string | null>(null);
 
     const gameClient = useRef<GameClient | null>(null);
 
@@ -55,12 +60,17 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
             setIsLoading(true);
             setShowStats(false);
             setGuess("");
+            setGameState(null);
+            setStartupError(null);
+            setActionError(null);
+            gameClient.current?.dispose();
 
             gameClient.current = new GameClient(
                 {
                     onStateUpdate: setGameState,
                     onError: (error) => {
                         console.error("Game error:", error);
+                        setActionError(error.message);
                     },
                     onRetry: (attempt, maxRetries) => {
                         console.log(`Retrying... (${attempt}/${maxRetries})`);
@@ -85,12 +95,14 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
             }
 
             setCountdown(AUTO_ADVANCE_DELAY_MS / 1000);
+            setActionError(null);
         } catch (error) {
             console.error("Failed to restart game:", error);
+            setStartupError(error instanceof Error ? error.message : t.errors.game.unknown);
         } finally {
             setIsLoading(false);
         }
-    }, [gameMode, gameVariant]);
+    }, [gameMode, gameVariant, t.errors.game.unknown]);
 
     useEffect(() => {
         handleStartGame();
@@ -105,16 +117,18 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
             if (isLoading) return;
 
             setIsLoading(true);
+            setActionError(null);
             try {
                 await action();
                 setGuess("");
             } catch (error) {
                 console.error("Action failed:", error);
+                setActionError(error instanceof Error ? error.message : t.errors.game.unknown);
             } finally {
                 setIsLoading(false);
             }
         },
-        [isLoading]
+        [isLoading, t.errors.game.unknown]
     );
 
     const handleGameComplete = useCallback(async () => {
@@ -168,6 +182,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                 return true;
             } catch (error) {
                 console.error("Failed to end game:", error);
+                setActionError(error instanceof Error ? error.message : t.errors.game.unknown);
                 return false;
             }
         } else {
@@ -180,10 +195,11 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                 return true;
             } catch (error) {
                 console.error("Failed to end game:", error);
+                setActionError(error instanceof Error ? error.message : t.errors.game.unknown);
                 return false;
             }
         }
-    }, [gameState, onExit, gameVariant]);
+    }, [gameState, onExit, gameVariant, t.errors.game.unknown]);
 
     useEffect(() => {
         if (!gameClient.current || !gameState) return;
@@ -232,6 +248,23 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
         }
     }, [gameState?.currentBeatmap.revealed, handleNextRound, isReportDialogOpen]);
 
+    if (!gameState && startupError) {
+        return (
+            <div className="container mx-auto flex min-h-[420px] items-center justify-center px-4 py-10">
+                <Alert variant="destructive" className="max-w-lg">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>{t.game.errors.startFailed}</AlertTitle>
+                    <AlertDescription className="mt-2 space-y-4">
+                        <p>{startupError}</p>
+                        <Button type="button" variant="outline" onClick={handleStartGame}>
+                            {t.game.actions.retry}
+                        </Button>
+                    </AlertDescription>
+                </Alert>
+            </div>
+        );
+    }
+
     if (!gameState) return <LoadingScreen />;
 
     if (showStats && gameState) {
@@ -244,6 +277,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                 averageTime={gameState.rounds.totalTimeUsed / gameState.rounds.current}
                 onPlayAgain={handleStartGame}
                 gameVariant={gameVariant}
+                gameEndReason={gameVariant === "death" ? getDeathEndReason(gameState) : undefined}
             />
         );
     }
@@ -274,6 +308,13 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                     {isLoading && <LoadingScreen />}
                 </div>
                 <div className="flex flex-col gap-6">
+                    {actionError && (
+                        <Alert variant="destructive" role="alert">
+                            <AlertCircle className="h-4 w-4" />
+                            <AlertTitle>{t.game.errors.actionFailed}</AlertTitle>
+                            <AlertDescription>{actionError}</AlertDescription>
+                        </Alert>
+                    )}
                     <GuessInput guess={guess} setGuess={setGuess} isRevealed={gameState.currentBeatmap.revealed} onGuess={handleGuess} onSkip={handleSkip} gameClient={gameClient.current!} />
 
                     <div className="bg-card p-6 rounded-lg border border-border/60">
@@ -294,7 +335,7 @@ export default function GameScreen({ onExit, gameVariant, gameMode, GameMedia }:
                     <Button variant="outline" onClick={handleExit} disabled={isLoading}>
                         {gameVariant === "death" ? t.game.actions.endRun : t.game.actions.exitGame}
                     </Button>
-                    {gameState.currentBeatmap.revealed && gameState.currentBeatmap.mapsetId && (
+                    {gameMode !== GameMode.Skin && gameState.currentBeatmap.revealed && gameState.currentBeatmap.mapsetId && (
                         <ReportDialog mapsetId={gameState.currentBeatmap.mapsetId} mapsetTitle={gameState.currentBeatmap.title || "Unknown"} onOpenChange={setIsReportDialogOpen} />
                     )}
                 </div>

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -26,14 +26,19 @@ export default function SettingsClient() {
     });
     const [newKeyName, setNewKeyName] = useState("");
     const [copied, setCopied] = useState(false);
+    const [keyLoadError, setKeyLoadError] = useState<string | null>(null);
+    const [operationError, setOperationError] = useState<string | null>(null);
+    const [copyError, setCopyError] = useState<string | null>(null);
 
     const loadApiKeys = useCallback(async () => {
         setLoading((prev) => ({ ...prev, keys: true }));
+        setKeyLoadError(null);
         try {
             const keys = await listApiKeysAction();
             setApiKeys(keys);
         } catch (error) {
             console.error(t.settings.apiKeys.errors.loadFailed, error);
+            setKeyLoadError(t.settings.apiKeys.errors.loadFailed);
         } finally {
             setLoading((prev) => ({ ...prev, keys: false }));
         }
@@ -48,6 +53,7 @@ export default function SettingsClient() {
         if (!newKeyName.trim()) return;
 
         setLoading((prev) => ({ ...prev, creation: true }));
+        setOperationError(null);
         try {
             const keyValue = await createApiKeyAction(newKeyName);
             await loadApiKeys();
@@ -55,6 +61,7 @@ export default function SettingsClient() {
             setDialogs((prev) => ({ ...prev, create: false, newKey: keyValue }));
         } catch (error) {
             console.error(t.settings.apiKeys.errors.createFailed, error);
+            setOperationError(t.settings.apiKeys.errors.createFailed);
         } finally {
             setLoading((prev) => ({ ...prev, creation: false }));
         }
@@ -64,12 +71,14 @@ export default function SettingsClient() {
         if (!dialogs.delete) return;
 
         setLoading((prev) => ({ ...prev, deletion: true }));
+        setOperationError(null);
         try {
             await deleteApiKeyAction(dialogs.delete.id);
             setApiKeys((prev) => prev.filter((key) => key.id !== dialogs.delete?.id));
             setDialogs((prev) => ({ ...prev, delete: null }));
         } catch (error) {
             console.error(t.settings.apiKeys.errors.deleteFailed, error);
+            setOperationError(t.settings.apiKeys.errors.deleteFailed);
         } finally {
             setLoading((prev) => ({ ...prev, deletion: false }));
         }
@@ -77,12 +86,14 @@ export default function SettingsClient() {
 
     async function copyKey(keyValue: string | null) {
         if (!keyValue) return;
+        setCopyError(null);
         try {
             await navigator.clipboard.writeText(keyValue);
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
         } catch (error) {
             console.error("Failed to copy key", error);
+            setCopyError(t.settings.apiKeys.errors.copyFailed);
         }
     }
 
@@ -105,6 +116,20 @@ export default function SettingsClient() {
             );
         }
 
+        if (keyLoadError) {
+            return (
+                <Alert variant="destructive" role="alert">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>{keyLoadError}</AlertTitle>
+                    <AlertDescription className="mt-3">
+                        <Button type="button" size="sm" variant="outline" onClick={loadApiKeys}>
+                            {t.settings.apiKeys.actions.retry}
+                        </Button>
+                    </AlertDescription>
+                </Alert>
+            );
+        }
+
         if (apiKeys.length === 0) {
             return <p className="text-center py-4 text-foreground/70">{t.settings.apiKeys.keyInfo.noKeys}</p>;
         }
@@ -121,7 +146,14 @@ export default function SettingsClient() {
                             <p className="text-sm text-foreground/70">{t.settings.apiKeys.keyInfo.neverUsed}</p>
                         )}
                     </div>
-                    <Button variant="destructive" onClick={() => setDialogs((prev) => ({ ...prev, delete: key }))} className="w-full sm:w-auto">
+                    <Button
+                        variant="destructive"
+                        onClick={() => {
+                            setOperationError(null);
+                            setDialogs((prev) => ({ ...prev, delete: key }));
+                        }}
+                        className="w-full sm:w-auto"
+                    >
                         {t.settings.apiKeys.actions.delete}
                     </Button>
                 </div>
@@ -161,7 +193,14 @@ export default function SettingsClient() {
                                 </AlertDescription>
                             </Alert>
 
-                            <Button onClick={() => setDialogs((prev) => ({ ...prev, create: true }))} disabled={apiKeys.length >= 5} className="w-full sm:w-auto">
+                            <Button
+                                onClick={() => {
+                                    setOperationError(null);
+                                    setDialogs((prev) => ({ ...prev, create: true }));
+                                }}
+                                disabled={apiKeys.length >= 5}
+                                className="w-full sm:w-auto"
+                            >
                                 {t.settings.apiKeys.actions.create}
                             </Button>
                         </div>
@@ -190,6 +229,12 @@ export default function SettingsClient() {
                         </DialogDescription>
                     </DialogHeader>
                     <div className="py-4">
+                        {operationError && (
+                            <Alert variant="destructive" role="alert" className="mb-4">
+                                <AlertCircle className="h-4 w-4" />
+                                <AlertTitle>{operationError}</AlertTitle>
+                            </Alert>
+                        )}
                         <Input value={newKeyName} onChange={(e) => setNewKeyName(e.target.value)} placeholder={t.settings.apiKeys.dialog.create.placeholder} className="w-full" />
                     </div>
                     <DialogFooter className="flex-col sm:flex-row gap-2">
@@ -217,6 +262,12 @@ export default function SettingsClient() {
                             </div>
                         </DialogDescription>
                     </DialogHeader>
+                    {operationError && (
+                        <Alert variant="destructive" role="alert">
+                            <AlertCircle className="h-4 w-4" />
+                            <AlertTitle>{operationError}</AlertTitle>
+                        </Alert>
+                    )}
                     <DialogFooter className="flex-col sm:flex-row gap-2">
                         <Button variant="outline" onClick={() => setDialogs((prev) => ({ ...prev, delete: null }))}>
                             {t.settings.apiKeys.actions.close}
@@ -248,6 +299,7 @@ export default function SettingsClient() {
                                             {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
                                         </Button>
                                     </div>
+                                    {copyError && <p role="alert" className="mt-2 text-sm text-destructive">{copyError}</p>}
                                 </div>
                             </div>
                         </DialogDescription>

--- a/src/app/user/[banchoId]/client.tsx
+++ b/src/app/user/[banchoId]/client.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { GameVariant } from "@/app/games/config";
 import { useTranslationsContext } from "@/context/translations-provider";
 import UserNotFound from "./NotFound";
+import { getHighestScore } from "@/lib/user-stats";
 
 interface GameStats {
     game_mode: GameMode;
@@ -188,7 +189,7 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
                         </div>
                     </div>
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
-                        <StatBox label={t.user.profile.stats.hiScore} value={Math.max(...(achievements?.map((a) => a.highest_score) ?? [0])).toLocaleString()} />
+                        <StatBox label={t.user.profile.stats.hiScore} value={getHighestScore(achievements).toLocaleString()} />
                         <StatBox label={t.user.profile.stats.totalGames} value={achievements?.reduce((sum, a) => sum + a.games_played, 0).toLocaleString() ?? "0"} />
                         <StatBox
                             label={t.user.profile.stats.globalRank}

--- a/src/app/user/[banchoId]/page.tsx
+++ b/src/app/user/[banchoId]/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from "next";
-import { GameVariant } from "@/app/games/config";
 import UserProfileClient from "./client";
-import { GameMode } from "@/actions/types";
+import { parseProfileFilters } from "@/lib/profile-params";
 
 export const dynamic = "force-dynamic";
 
@@ -19,9 +18,8 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function UserProfile({ params, searchParams }: Props) {
     const { banchoId } = await params;
-    const { mode = "background", variant = "classic" } = await searchParams;
-    const currentMode = mode as GameMode;
-    const currentVariant = variant as GameVariant;
+    const { mode, variant } = await searchParams;
+    const { mode: currentMode, variant: currentVariant } = parseProfileFilters(mode, variant);
 
     return <UserProfileClient currentMode={currentMode} currentVariant={currentVariant} banchoId={banchoId} />;
 }

--- a/src/lib/game/result.test.ts
+++ b/src/lib/game/result.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { GameState } from "@/actions/types";
+import { getDeathEndReason } from "./result";
+
+const finishedState: GameState = {
+    sessionId: "00000000-0000-4000-8000-000000000000",
+    currentBeatmap: { revealed: true },
+    score: { total: 0, current: 0, streak: 0, highestStreak: 3 },
+    rounds: { current: 4, total: 4, correctGuesses: 3, totalTimeUsed: 20 },
+    timeLeft: 0,
+    gameStatus: "finished",
+    variant: "death",
+};
+
+describe("getDeathEndReason", () => {
+    test("marks an incorrect terminal answer as a failed run", () => {
+        expect(getDeathEndReason({ ...finishedState, lastGuess: { correct: false, answer: "answer", type: "guess" } })).toBe("died");
+    });
+
+    test("marks content exhaustion after a correct answer as completion", () => {
+        expect(getDeathEndReason({ ...finishedState, lastGuess: { correct: true, answer: "answer", type: "guess" } })).toBe("completed");
+    });
+
+    test("marks a manually ended active run as failed", () => {
+        expect(getDeathEndReason({ ...finishedState, gameStatus: "active" })).toBe("died");
+    });
+});

--- a/src/lib/game/result.ts
+++ b/src/lib/game/result.ts
@@ -1,0 +1,5 @@
+import { GameState } from "@/actions/types";
+
+export function getDeathEndReason(gameState: GameState): "completed" | "died" {
+    return gameState.gameStatus === "finished" && gameState.lastGuess?.correct !== false ? "completed" : "died";
+}

--- a/src/lib/profile-params.test.ts
+++ b/src/lib/profile-params.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { GameMode } from "@/actions/types";
+import { parseProfileFilters } from "./profile-params";
+
+describe("parseProfileFilters", () => {
+    test("accepts supported profile filters", () => {
+        expect(parseProfileFilters("audio", "death")).toEqual({ mode: GameMode.Audio, variant: "death" });
+    });
+
+    test("falls back when profile filters are missing or invalid", () => {
+        expect(parseProfileFilters()).toEqual({ mode: GameMode.Background, variant: "classic" });
+        expect(parseProfileFilters("invalid", "endless")).toEqual({ mode: GameMode.Background, variant: "classic" });
+    });
+});

--- a/src/lib/profile-params.ts
+++ b/src/lib/profile-params.ts
@@ -1,0 +1,13 @@
+import { GameMode } from "@/actions/types";
+import { GameVariant } from "@/app/games/config";
+import { z } from "zod";
+
+const profileModeSchema = z.nativeEnum(GameMode).catch(GameMode.Background);
+const profileVariantSchema = z.enum(["classic", "death"]).catch("classic");
+
+export function parseProfileFilters(mode?: string, variant?: string): { mode: GameMode; variant: GameVariant } {
+    return {
+        mode: profileModeSchema.parse(mode),
+        variant: profileVariantSchema.parse(variant),
+    };
+}

--- a/src/lib/user-stats.test.ts
+++ b/src/lib/user-stats.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { GameMode, UserAchievement } from "@/actions/types";
+import { getHighestScore, hasPlayedGame } from "./user-stats";
+
+const audioAchievement: UserAchievement = {
+    user_id: 1,
+    game_mode: GameMode.Audio,
+    variant: "classic",
+    total_score: 100n,
+    games_played: 2,
+    highest_streak: 1,
+    highest_score: 75,
+    last_played: new Date(0),
+};
+
+describe("user stat helpers", () => {
+    test("returns zero for an empty high score", () => {
+        expect(getHighestScore()).toBe(0);
+        expect(getHighestScore([audioAchievement])).toBe(75);
+    });
+
+    test("only considers variants and modes with completed games as ranked", () => {
+        expect(hasPlayedGame([audioAchievement], "classic", GameMode.Audio)).toBe(true);
+        expect(hasPlayedGame([audioAchievement], "death", GameMode.Audio)).toBe(false);
+        expect(hasPlayedGame([audioAchievement], "classic", GameMode.Background)).toBe(false);
+    });
+});

--- a/src/lib/user-stats.ts
+++ b/src/lib/user-stats.ts
@@ -1,0 +1,9 @@
+import { GameMode, GameVariant, UserAchievement } from "@/actions/types";
+
+export function getHighestScore(achievements: UserAchievement[] = []): number {
+    return achievements.reduce((highest, achievement) => Math.max(highest, achievement.highest_score), 0);
+}
+
+export function hasPlayedGame(achievements: UserAchievement[], variant: GameVariant, mode?: GameMode): boolean {
+    return achievements.some((achievement) => achievement.variant === variant && achievement.games_played > 0 && (!mode || achievement.game_mode === mode));
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -454,7 +454,12 @@
             "exitGame": "Exit Game",
             "nextRound": "Next Round",
             "nextRoundTime": "Next Round ({seconds}s)",
-            "viewResults": "View Results"
+            "viewResults": "View Results",
+            "retry": "Try Again"
+        },
+        "errors": {
+            "startFailed": "The game could not be started",
+            "actionFailed": "The game action could not be completed"
         },
         "shortcuts": {
             "title": "Some shortcuts you should know:",
@@ -482,7 +487,9 @@
         },
         "audio": {
             "instructions": "Listen to the audio and try to guess the song title!",
-            "browserNotSupported": "Your browser does not support the audio element."
+            "browserNotSupported": "Your browser does not support the audio element.",
+            "loadFailed": "The audio could not be loaded or played.",
+            "retry": "Retry audio"
         }
     },
     "leaderboard": {
@@ -574,7 +581,8 @@
                 "delete": "Delete Key",
                 "viewDocs": "View API Documentation",
                 "copy": "Copy Key",
-                "close": "Close"
+                "close": "Close",
+                "retry": "Try Again"
             },
             "dialog": {
                 "create": {
@@ -612,6 +620,7 @@
                 "createFailed": "Failed to create API key",
                 "deleteFailed": "Failed to delete API key",
                 "loadFailed": "Failed to load API keys",
+                "copyFailed": "Failed to copy the API key",
                 "maxKeysReached": "Maximum number of API keys (5) reached"
             }
         }


### PR DESCRIPTION
Profile and game edge cases now fail safely and visibly instead of crashing, hanging, or silently logging failures.

- Validates profile mode and variant filters with safe defaults.
- Shows zero for an empty high score and leaves users without games unranked.
- Replaces failed game startup loading with an error and retry action.
- Surfaces game-action, audio-load, audio-playback, and API-key operation failures in the UI.
- Distinguishes failed death-mode runs from completed content.
- Hides mapset reporting for skin games.
- Adds focused tests for profile parsing, empty stats, rank eligibility, and death-run outcomes.

Tests:
- `bun run check` — passed.
- `bun test` — passed (42 tests).
- `bun run build` — passed.

Visible change notes:
- Startup and in-game failures now render destructive alerts with useful retry guidance.
- API-key loading failure has its own retry state and no longer looks like an empty key list.
- Audio failures stop the spinner after an error or 15-second timeout and offer retry.

Remaining limitation:
- The existing `GameClient.endGame()` behavior intentionally swallows persistence failures. This PR does not change score persistence because that area is explicitly out of scope.