### PR TITLE
fix(a11y): improve navigation and responsive states

### DIFF
--- a/src/app/games/shared/components/GuessInput.tsx
+++ b/src/app/games/shared/components/GuessInput.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useId, useRef } from "react";
 import { GameClient } from "@/lib/game/client";
 import { useTranslationsContext } from "@/context/translations-provider";
 import { soundManager } from "@/lib/game/sounds";
@@ -18,6 +18,8 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
     const [suggestions, setSuggestions] = useState<string[]>([]);
     const [showSuggestions, setShowSuggestions] = useState(false);
     const [selectedIndex, setSelectedIndex] = useState(-1);
+    const [announcement, setAnnouncement] = useState("");
+    const listboxId = useId();
 
     const clickingRef = useRef(false);
     const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -49,6 +51,7 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
                 setSuggestions(newSuggestions);
                 setShowSuggestions(true);
                 setSelectedIndex(newSuggestions.length > 0 ? 0 : -1);
+                setAnnouncement(t.game.input.suggestionsAvailable.replace("{count}", newSuggestions.length.toString()));
             }, 100);
         }
 
@@ -57,7 +60,7 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
                 clearTimeout(debounceTimeoutRef.current);
             }
         };
-    }, [guess, gameClient, isRevealed]);
+    }, [guess, gameClient, isRevealed, t.game.input.suggestionsAvailable]);
 
     useEffect(() => {
         setSuggestions([]);
@@ -73,6 +76,12 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
             setSelectedIndex(-1);
         }
     }, [suggestions]);
+
+    useEffect(() => {
+        if (showSuggestions && selectedIndex >= 0 && suggestions[selectedIndex]) {
+            setAnnouncement(t.game.input.suggestionSelected.replace("{suggestion}", suggestions[selectedIndex]));
+        }
+    }, [selectedIndex, showSuggestions, suggestions, t.game.input.suggestionSelected]);
 
     const handleSubmit = () => {
         soundManager.play("click");
@@ -91,6 +100,7 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
         setGuess(suggestion);
         setShowSuggestions(false);
         setSuggestions([]);
+        setAnnouncement(t.game.input.suggestionSelected.replace("{suggestion}", suggestion));
         setTimeout(() => {
             isSelectingRef.current = false;
         }, 100);
@@ -165,14 +175,23 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
                     className="w-full p-3 rounded-lg bg-secondary text-foreground border border-border/50 transition-[border-color,box-shadow,background-color,opacity] duration-150 ease-[var(--ease-out-smooth)] focus:outline-none focus:border-primary/55 focus:ring-2 focus:ring-primary focus:shadow-[0_0_0_4px_hsl(var(--primary)/0.08)] disabled:opacity-60"
                     placeholder={t.game.input.placeholder}
                     disabled={isRevealed}
+                    role="combobox"
+                    aria-label={t.game.input.title}
+                    aria-autocomplete="list"
+                    aria-expanded={showSuggestions && suggestions.length > 0}
+                    aria-controls={showSuggestions && suggestions.length > 0 ? listboxId : undefined}
+                    aria-activedescendant={showSuggestions && selectedIndex >= 0 ? `${listboxId}-option-${selectedIndex}` : undefined}
                 />
 
                 {showSuggestions && suggestions.length > 0 && (
-                    <div className="motion-scale-in absolute w-full mt-1 bg-card border border-border/50 rounded-lg shadow-lg overflow-hidden z-50 origin-top">
+                    <div id={listboxId} role="listbox" aria-label={t.game.input.suggestions} className="motion-scale-in absolute w-full mt-1 bg-card border border-border/50 rounded-lg shadow-lg overflow-hidden z-50 origin-top">
                         <div className="max-h-[300px] overflow-y-auto backdrop-blur-sm">
                             {suggestions.map((suggestion, index) => (
                                 <div
                                     key={suggestion}
+                                    id={`${listboxId}-option-${index}`}
+                                    role="option"
+                                    aria-selected={index === selectedIndex}
                                     className={`px-4 py-2 cursor-pointer transition-[background-color,color] duration-150 ease-[var(--ease-out-smooth)]
                                                ${index === selectedIndex ? "bg-primary/10 text-primary font-medium" : "hover:bg-secondary/50"}`}
                                     onMouseDown={() => {
@@ -191,6 +210,9 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
                     </div>
                 )}
             </div>
+            <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                {announcement}
+            </span>
             <div className="flex gap-4 mt-4">
                 <Button className="flex-1" onClick={onGuess} disabled={!guess || isRevealed}>
                     {t.game.input.submit}

--- a/src/app/leaderboard/client.tsx
+++ b/src/app/leaderboard/client.tsx
@@ -85,22 +85,36 @@ export default function LeaderboardClient() {
             </div>
 
             <div className="bg-card rounded-lg border border-border/60 overflow-hidden">
-                <div className="overflow-x-auto">
-                    <table className="w-full">
-                        <thead className="bg-secondary/50">
+                {isLoading ? (
+                    <div className="p-8 text-center" role="status">
+                        {t.common.loading}
+                    </div>
+                ) : error ? (
+                    <div className="p-8 text-center text-destructive" role="alert">
+                        {error}
+                    </div>
+                ) : leaderboardData.length === 0 ? (
+                    <div className="p-8 text-center text-foreground/70" role="status">
+                        {t.leaderboard.empty}
+                    </div>
+                ) : (
+                    <div className="overflow-x-auto">
+                        <table className="w-full table-fixed sm:table-auto">
+                            <caption className="sr-only">{t.leaderboard.title}</caption>
+                            <thead className="bg-secondary/50">
                             <tr>
-                                <th className="px-6 py-4 text-left">{t.leaderboard.table.rank}</th>
-                                <th className="px-6 py-4 text-left">{t.leaderboard.table.player}</th>
+                                <th scope="col" className="w-14 px-3 py-3 text-left sm:w-auto sm:px-6 sm:py-4">{t.leaderboard.table.rank}</th>
+                                <th scope="col" className="px-2 py-3 text-left sm:px-6 sm:py-4">{t.leaderboard.table.player}</th>
                                 {selectedVariant === "classic" && (
-                                    <th className="px-6 py-4 text-right">
+                                    <th scope="col" className="hidden px-3 py-3 text-right sm:table-cell sm:px-6 sm:py-4">
                                         <Button variant="ghost" size="sm" onClick={() => setOrderMetric("total")} className="h-auto p-0 font-semibold hover:bg-transparent">
                                             {t.leaderboard.table.totalScore}
                                             {orderMetric === "total" && <ChevronDownIcon className="ml-1 h-3 w-3" />}
                                         </Button>
                                     </th>
                                 )}
-                                <th className="px-6 py-4 text-right">{t.leaderboard.table.gamesPlayed}</th>
-                                <th className="px-6 py-4 text-right">
+                                <th scope="col" className="hidden px-6 py-4 text-right md:table-cell">{t.leaderboard.table.gamesPlayed}</th>
+                                <th scope="col" className="w-20 px-3 py-3 text-right text-xs sm:w-auto sm:px-6 sm:py-4 sm:text-base">
                                     {selectedVariant === "classic" ? (
                                         <Button variant="ghost" size="sm" onClick={() => setOrderMetric("highest")} className="h-auto p-0 font-semibold hover:bg-transparent">
                                             {t.leaderboard.table.hiScore}
@@ -111,24 +125,11 @@ export default function LeaderboardClient() {
                                     )}
                                 </th>
                             </tr>
-                        </thead>
-                        <tbody className="divide-y divide-border/50">
-                            {isLoading ? (
-                                <tr>
-                                    <td colSpan={selectedVariant === "classic" ? 5 : 4} className="p-8 text-center">
-                                        {t.common.loading}
-                                    </td>
-                                </tr>
-                            ) : error ? (
-                                <tr>
-                                    <td colSpan={selectedVariant === "classic" ? 5 : 4} className="p-8 text-center text-destructive">
-                                        <p>{error}</p>
-                                    </td>
-                                </tr>
-                            ) : leaderboardData.length > 0 ? (
-                                leaderboardData.map((player, index) => (
+                            </thead>
+                            <tbody className="divide-y divide-border/50">
+                                {leaderboardData.map((player, index) => (
                                     <tr key={player.bancho_id} className={`hover:bg-secondary/20 transition-colors ${session?.user?.name === player.username ? "bg-primary/10" : ""}`}>
-                                        <td className="px-6 py-4">
+                                        <td className="px-3 py-3 sm:px-6 sm:py-4">
                                             {index + 1 <= 3 && page === 1 ? (
                                                 <div className="flex items-center justify-center w-8 h-8 rounded-full bg-secondary text-foreground font-bold text-sm ring-1 ring-border/70">
                                                     {(page - 1) * pageSize + index + 1}
@@ -137,23 +138,23 @@ export default function LeaderboardClient() {
                                                 <span className="text-muted-foreground font-mono">{(page - 1) * pageSize + index + 1}</span>
                                             )}
                                         </td>
-                                        <td className="px-6 py-4">
-                                            <Link href={`/user/${player.bancho_id}`} className="flex items-center gap-3 hover:text-primary transition-colors group">
+                                        <td className="min-w-0 px-2 py-3 sm:px-6 sm:py-4">
+                                            <Link href={`/user/${player.bancho_id}`} className="group flex min-w-0 items-center gap-2 transition-colors hover:text-primary sm:gap-3">
                                                 <Image
                                                     src={player.avatar_url || "/placeholder.svg"}
-                                                    alt={player.username}
+                                                    alt=""
                                                     width={32}
                                                     height={32}
                                                     className="rounded-full ring-2 ring-transparent group-hover:ring-primary/20 transition-all"
                                                 />
-                                                <div className="flex items-center gap-2">
-                                                    <span className="font-medium">{player.username}</span>
+                                                <div className="flex min-w-0 items-center gap-2">
+                                                    <span className="truncate font-medium">{player.username}</span>
                                                     {player.badges &&
                                                         player.badges.map((badge, badgeIndex) => (
                                                             <Badge
                                                                 key={badgeIndex}
                                                                 variant="secondary"
-                                                                className="text-xs"
+                                                                className="hidden text-xs lg:inline-flex"
                                                                 style={{
                                                                     backgroundColor: `${badge.color}15`,
                                                                     color: badge.color,
@@ -166,21 +167,15 @@ export default function LeaderboardClient() {
                                                 </div>
                                             </Link>
                                         </td>
-                                        {selectedVariant === "classic" && <td className="px-6 py-4 text-right font-mono text-sm">{BigInt(player.total_score).toLocaleString()}</td>}
-                                        <td className="px-6 py-4 text-right font-mono text-sm text-muted-foreground">{player.games_played}</td>
-                                        <td className="px-6 py-4 text-right font-mono text-sm font-semibold">{selectedVariant === "classic" ? player.highest_score : player.highest_streak}</td>
+                                        {selectedVariant === "classic" && <td className="hidden px-6 py-4 text-right font-mono text-sm sm:table-cell">{BigInt(player.total_score).toLocaleString()}</td>}
+                                        <td className="hidden px-6 py-4 text-right font-mono text-sm text-muted-foreground md:table-cell">{player.games_played}</td>
+                                        <td className="px-3 py-3 text-right font-mono text-sm font-semibold sm:px-6 sm:py-4">{selectedVariant === "classic" ? player.highest_score : player.highest_streak}</td>
                                     </tr>
-                                ))
-                            ) : (
-                                <tr>
-                                    <td colSpan={selectedVariant === "classic" ? 5 : 4} className="p-8 text-center text-foreground/70">
-                                        <p>{t.leaderboard.empty}</p>
-                                    </td>
-                                </tr>
-                            )}
-                        </tbody>
-                    </table>
-                </div>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-3 items-center gap-4 mt-4">

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -244,7 +244,13 @@ export default function SettingsClient() {
                                 <div className="mt-4">
                                     <div className="flex items-center gap-2 p-2 bg-background rounded border border-border/50">
                                         <code className="font-mono text-sm flex-1 break-all px-2">{dialogs.newKey}</code>
-                                        <Button size="icon" variant="ghost" onClick={() => copyKey(dialogs.newKey)} className="flex-shrink-0">
+                                        <Button
+                                            size="icon"
+                                            variant="ghost"
+                                            onClick={() => copyKey(dialogs.newKey)}
+                                            className="flex-shrink-0"
+                                            aria-label={copied ? t.settings.apiKeys.dialog.created.copied : t.settings.apiKeys.actions.copy}
+                                        >
                                             {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
                                         </Button>
                                     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,6 +14,7 @@ import { SupportPageLink } from "./SupportDialogWrapper";
 import { OWNER_ID } from "@/lib";
 
 const NAV_ITEMS = ["leaderboard", "about", "announcements"] as const;
+const MOBILE_NAV_ID = "mobile-navigation";
 
 export default function Header() {
     const { data: session } = useSession();
@@ -32,9 +33,9 @@ export default function Header() {
 
     return (
         <header className="bg-background/95 backdrop-blur-md border-b sticky top-0 z-50 shadow-sm">
-            <div className="container mx-auto px-4 py-3 flex justify-between items-center">
-                <div className="flex items-center space-x-8">
-                    <Link href="/" className="text-2xl font-bold text-primary hover:text-primary/80 transition-[color,opacity] duration-150 ease-[var(--ease-out-smooth)]">
+            <div className="container mx-auto flex items-center justify-between gap-2 px-2 py-3 sm:px-4">
+                <div className="flex min-w-0 items-center space-x-8">
+                    <Link href="/" className="whitespace-nowrap text-xl font-bold text-primary transition-[color,opacity] duration-150 ease-[var(--ease-out-smooth)] hover:text-primary/80 sm:text-2xl">
                         osu!guessr
                     </Link>
                     <nav className="hidden md:block">
@@ -53,20 +54,28 @@ export default function Header() {
                     </nav>
                 </div>
 
-                <div className="flex items-center gap-4">
+                <div className="flex shrink-0 items-center gap-1 sm:gap-4">
                     <LanguageSwitcher />
                     <div className="hidden md:block">
                         <SupportPageLink />
                     </div>
 
-                    <Button variant="ghost" className="md:hidden" onClick={() => setIsMenuOpen(!isMenuOpen)} aria-expanded={isMenuOpen}>
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="md:hidden"
+                        onClick={() => setIsMenuOpen(!isMenuOpen)}
+                        aria-label={isMenuOpen ? t.components.header.accessibility.closeMenu : t.components.header.accessibility.openMenu}
+                        aria-expanded={isMenuOpen}
+                        aria-controls={MOBILE_NAV_ID}
+                    >
                         <Menu className="h-6 w-6" />
                     </Button>
 
                     {session ? (
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                                <Button variant="ghost" className="relative h-10 w-10 rounded-full p-0 active:!transform-none">
+                                <Button variant="ghost" className="relative h-10 w-10 rounded-full p-0 active:!transform-none" aria-label={t.components.header.accessibility.profileMenu}>
                                     <Image src={session.user?.image || "/default-avatar.png"} alt="Avatar" className="rounded-full" fill style={{ objectFit: "cover" }} />
                                 </Button>
                             </DropdownMenuTrigger>
@@ -97,37 +106,37 @@ export default function Header() {
                             </DropdownMenuContent>
                         </DropdownMenu>
                     ) : (
-                        <Button onClick={() => signIn("osu")}>{t.components.header.nav.signIn}</Button>
+                        <Button onClick={() => signIn("osu")} className="px-2 text-xs sm:px-4 sm:text-sm">
+                            {t.components.header.nav.signIn}
+                        </Button>
                     )}
                 </div>
 
-                <nav
-                    className={`${
-                        isMenuOpen ? "max-h-[500px] opacity-100 translate-y-0" : "max-h-0 opacity-0 -translate-y-2"
-                    } md:hidden overflow-hidden transition-all duration-200 ease-[var(--ease-out-smooth)] absolute top-full left-0 w-full bg-background shadow-md`}
-                >
-                    <ul className="flex flex-col space-y-4 items-center py-4">
-                        <li className="w-full px-4">
-                            <UserSearch />
-                        </li>
-                        {NAV_ITEMS.map((item) => (
-                            <li className="flex items-center w-full" key={item}>
-                                <Link
-                                    href={`/${item}`}
-                                    className="text-foreground/80 hover:text-primary transition-colors duration-200 font-medium w-full text-center px-4 py-2"
-                                    onClick={() => setIsMenuOpen(false)}
-                                >
-                                    {getNavLabel(item)}
-                                </Link>
+                {isMenuOpen && (
+                    <nav id={MOBILE_NAV_ID} aria-label={t.components.header.accessibility.mobileNavigation} className="absolute left-0 top-full w-full bg-background shadow-md md:hidden">
+                        <ul className="flex flex-col items-center space-y-4 py-4">
+                            <li className="w-full px-4">
+                                <UserSearch />
                             </li>
-                        ))}
-                        <li className="flex items-center w-full">
-                            <div className="w-full text-center px-4 py-2" onClick={() => setIsMenuOpen(false)}>
-                                <SupportPageLink />
-                            </div>
-                        </li>
-                    </ul>
-                </nav>
+                            {NAV_ITEMS.map((item) => (
+                                <li className="flex w-full items-center" key={item}>
+                                    <Link
+                                        href={`/${item}`}
+                                        className="w-full px-4 py-2 text-center font-medium text-foreground/80 transition-colors duration-200 hover:text-primary"
+                                        onClick={() => setIsMenuOpen(false)}
+                                    >
+                                        {getNavLabel(item)}
+                                    </Link>
+                                </li>
+                            ))}
+                            <li className="flex w-full items-center">
+                                <div className="w-full px-4 py-2 text-center" onClick={() => setIsMenuOpen(false)}>
+                                    <SupportPageLink />
+                                </div>
+                            </li>
+                        </ul>
+                    </nav>
+                )}
             </div>
         </header>
     );

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -3,15 +3,16 @@
 import { Button } from "./ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./ui/dropdown-menu";
 import { Globe } from "lucide-react";
-import { useTranslations, languages, Locale } from "@/hooks/use-translations";
+import { languages, Locale } from "@/hooks/use-translations";
+import { useTranslationsContext } from "@/context/translations-provider";
 
 export function LanguageSwitcher() {
-    const { locale, setLanguage } = useTranslations();
+    const { locale, setLanguage, t } = useTranslationsContext();
 
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon">
+                <Button variant="ghost" size="icon" aria-label={t.components.header.accessibility.changeLanguage}>
                     <Globe className="h-4 w-4" />
                 </Button>
             </DropdownMenuTrigger>

--- a/src/components/UserSearch.tsx
+++ b/src/components/UserSearch.tsx
@@ -78,32 +78,45 @@ export default function UserSearch() {
                     <DialogTitle>{t.user.search.title}</DialogTitle>
                     <DialogDescription>{t.user.search.description}</DialogDescription>
                 </VisuallyHidden>
-                <div className="p-4 border-b">
+                <form role="search" aria-label={t.user.search.title} className="border-b p-4" onSubmit={(event) => event.preventDefault()}>
                     <div className="relative">
                         <Search className="absolute left-3 top-2.5 h-4 w-4 text-foreground/50" />
-                        <Input autoFocus type="text" value={query} onChange={(e) => setQuery(e.target.value)} placeholder={t.user.search.placeholder} className="pl-9 pr-4" />
+                        <Input
+                            autoFocus
+                            type="search"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            placeholder={t.user.search.placeholder}
+                            aria-label={t.user.search.placeholder}
+                            className="pl-9 pr-4"
+                        />
                     </div>
-                </div>
+                </form>
 
-                <div className="max-h-[60vh] overflow-y-auto">
+                <span className="sr-only" role="status" aria-live="polite">
+                    {isSearching ? t.user.search.searching : results.length > 0 ? t.user.search.resultsFound.replace("{count}", results.length.toString()) : ""}
+                </span>
+
+                <div className="max-h-[60vh] overflow-y-auto" aria-busy={isSearching}>
                     {isSearching ? (
                         <div className="p-8 text-center text-foreground/70">
                             <span className="soft-loading-dot inline-block">{t.user.search.searching}</span>
                         </div>
                     ) : results.length > 0 ? (
-                        <div className="py-2">
+                        <ul className="py-2" aria-label={t.user.search.results}>
                             {results.map((user) => (
-                                <Link
-                                    key={user.bancho_id.toString()}
-                                    href={`/user/${user.bancho_id.toString()}`}
-                                    className="w-full flex items-center gap-3 px-4 py-3 hover:bg-accent/50 transition-[background-color,color] duration-150 ease-[var(--ease-out-smooth)]"
-                                    onClick={() => handleSelect()}
-                                >
-                                    <Image src={user.avatar_url || "/placeholder.svg"} alt={user.username} width={40} height={40} className="rounded-full" />
-                                    <span className="font-medium">{user.username}</span>
-                                </Link>
+                                <li key={user.bancho_id.toString()}>
+                                    <Link
+                                        href={`/user/${user.bancho_id.toString()}`}
+                                        className="flex w-full items-center gap-3 px-4 py-3 transition-[background-color,color] duration-150 ease-[var(--ease-out-smooth)] hover:bg-accent/50"
+                                        onClick={() => handleSelect()}
+                                    >
+                                        <Image src={user.avatar_url || "/placeholder.svg"} alt="" width={40} height={40} className="rounded-full" />
+                                        <span className="font-medium">{user.username}</span>
+                                    </Link>
+                                </li>
                             ))}
-                        </div>
+                        </ul>
                     ) : query.length >= 2 ? (
                         <div className="p-8 text-center text-foreground/70">{t.user.search.noResults}</div>
                     ) : (

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -403,7 +403,10 @@
             "placeholder": "Song title...",
             "title": "Enter your guess:",
             "submit": "Submit",
-            "skip": "Skip (-50 points)"
+            "skip": "Skip (-50 points)",
+            "suggestions": "Guess suggestions",
+            "suggestionsAvailable": "{count} suggestions available.",
+            "suggestionSelected": "Selected {suggestion}."
         },
         "header": {
             "title": "{mode} Guessr",
@@ -552,7 +555,9 @@
             "shortcut": "⌘K",
             "noResults": "No users found",
             "startTyping": "Start typing to search users",
-            "searching": "Searching..."
+            "searching": "Searching...",
+            "results": "User search results",
+            "resultsFound": "{count} users found"
         }
     },
     "settings": {
@@ -653,6 +658,13 @@
             }
         },
         "header": {
+            "accessibility": {
+                "openMenu": "Open navigation menu",
+                "closeMenu": "Close navigation menu",
+                "mobileNavigation": "Mobile navigation",
+                "changeLanguage": "Change language",
+                "profileMenu": "Open profile menu"
+            },
             "nav": {
                 "leaderboard": "Leaderboard",
                 "about": "About",


### PR DESCRIPTION
Navigation, search, autocomplete, and leaderboard controls now remain usable at narrow widths and expose the semantics assistive technology needs.

- Fits the signed-out header within 320px using compact mobile spacing and sizing.
- Gives the mobile menu complete expanded/control labelling and unmounts its contents when closed so hidden links cannot receive focus.
- Adds accessible names to the menu, language, profile, and API-key copy controls.
- Gives user search explicit search and result-list semantics with live result counts.
- Implements combobox/listbox roles, active descendants, option selection state, keyboard navigation, and announcements for guess suggestions while preserving existing shortcuts.
- Moves leaderboard loading, error, and empty states outside the wide table and hides lower-priority columns on small screens.

Tests:
- `bun run check` — passed.
- `bun test` — passed (35 tests).
- `bun run build` — passed.

Visible change notes:
- At 320px the header uses a smaller wordmark, compact gaps, and compact sign-in sizing instead of overflowing horizontally.
- Mobile leaderboard rows prioritize rank, player, and score/streak; total score and games played return at larger breakpoints.
- Desktop layout and visual styling are otherwise preserved.

Remaining limitation:
- The repository has no DOM/component testing dependency, so the ARIA and 320px changes are validated by lint, TypeScript, production build, and code-level review rather than automated browser assertions.