### PR TITLE
fix(client): prevent stale request state updates

### DIFF
--- a/src/app/games/shared/components/GuessInput.tsx
+++ b/src/app/games/shared/components/GuessInput.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useId, useRef } from "react";
 import { GameClient } from "@/lib/game/client";
 import { useTranslationsContext } from "@/context/translations-provider";
 import { soundManager } from "@/lib/game/sounds";
+import { createLatestRequestGate } from "@/lib/latest-request";
 
 interface GuessInputProps {
     guess: string;
@@ -25,6 +26,7 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
     const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const isSelectingRef = useRef(false);
     const inputRef = useRef<HTMLInputElement>(null);
+    const requestGate = useRef(createLatestRequestGate());
 
     useEffect(() => {
         if (!isRevealed && inputRef.current) {
@@ -41,17 +43,31 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
     }, [guess]);
 
     useEffect(() => {
+        const request = requestGate.current.begin();
+
         if (!isSelectingRef.current && guess.trim() && !isRevealed) {
             if (debounceTimeoutRef.current) {
                 clearTimeout(debounceTimeoutRef.current);
             }
 
             debounceTimeoutRef.current = setTimeout(async () => {
-                const newSuggestions = await gameClient.getSuggestions(guess);
-                setSuggestions(newSuggestions);
-                setShowSuggestions(true);
-                setSelectedIndex(newSuggestions.length > 0 ? 0 : -1);
-                setAnnouncement(t.game.input.suggestionsAvailable.replace("{count}", newSuggestions.length.toString()));
+                try {
+                    const newSuggestions = await gameClient.getSuggestions(guess);
+                    if (request.isCurrent()) {
+                        setSuggestions(newSuggestions);
+                        setShowSuggestions(newSuggestions.length > 0);
+                        setSelectedIndex(newSuggestions.length > 0 ? 0 : -1);
+                        setAnnouncement(t.game.input.suggestionsAvailable.replace("{count}", newSuggestions.length.toString()));
+                    }
+                } catch (error) {
+                    if (request.isCurrent()) {
+                        console.error("Failed to load suggestions:", error);
+                        setSuggestions([]);
+                        setShowSuggestions(false);
+                        setSelectedIndex(-1);
+                        setAnnouncement("");
+                    }
+                }
             }, 100);
         }
 
@@ -59,6 +75,7 @@ export default function GuessInput({ guess, setGuess, isRevealed, onGuess, onSki
             if (debounceTimeoutRef.current) {
                 clearTimeout(debounceTimeoutRef.current);
             }
+            request.cancel();
         };
     }, [guess, gameClient, isRevealed, t.game.input.suggestionsAvailable]);
 

--- a/src/app/leaderboard/client.tsx
+++ b/src/app/leaderboard/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
@@ -13,6 +13,7 @@ import { GameMode, type TopPlayer } from "@/actions/types";
 import type { GameVariant } from "@/app/games/config";
 import { useTranslationsContext } from "@/context/translations-provider";
 import { AdSlider } from "@/components/Ads";
+import { createLatestRequestGate } from "@/lib/latest-request";
 
 export default function LeaderboardClient() {
     const { t } = useTranslationsContext();
@@ -25,10 +26,13 @@ export default function LeaderboardClient() {
     const [orderMetric, setOrderMetric] = useState<"total" | "highest">("highest");
     const [page, setPage] = useState<number>(1);
     const [pageSize, setPageSize] = useState<number>(10);
+    const requestGate = useRef(createLatestRequestGate());
 
     const errorMessage = t.notifications.error;
 
     useEffect(() => {
+        const request = requestGate.current.begin();
+
         async function fetchLeaderboard() {
             setIsLoading(true);
             setError(null);
@@ -36,16 +40,23 @@ export default function LeaderboardClient() {
             try {
                 const offset = (page - 1) * pageSize;
                 const data = await getTopPlayersAction(selectedMode, selectedVariant, pageSize, orderMetric, offset);
-                setLeaderboardData(data);
+                if (request.isCurrent()) {
+                    setLeaderboardData(data);
+                }
             } catch (error) {
-                console.error("Failed to fetch leaderboard:", error);
-                setError(error instanceof Error ? error.message : errorMessage);
+                if (request.isCurrent()) {
+                    console.error("Failed to fetch leaderboard:", error);
+                    setError(error instanceof Error ? error.message : errorMessage);
+                }
             } finally {
-                setIsLoading(false);
+                if (request.isCurrent()) {
+                    setIsLoading(false);
+                }
             }
         }
 
-        fetchLeaderboard();
+        void fetchLeaderboard();
+        return () => request.cancel();
     }, [selectedMode, selectedVariant, orderMetric, page, pageSize, errorMessage]);
 
     const gameModes: GameMode[] = [GameMode.Background, GameMode.Audio, GameMode.Skin];
@@ -57,7 +68,13 @@ export default function LeaderboardClient() {
             <div className="flex flex-col md:flex-row md:flex-wrap items-stretch md:items-center justify-center gap-4 mb-8 p-4 bg-card rounded-lg border border-border/60">
                 <div className="flex items-center justify-between gap-2 md:justify-start">
                     <span className="text-sm font-medium text-muted-foreground">Mode:</span>
-                    <Select value={selectedMode} onValueChange={(value: GameMode) => setSelectedMode(value)}>
+                    <Select
+                        value={selectedMode}
+                        onValueChange={(value: GameMode) => {
+                            setSelectedMode(value);
+                            setPage(1);
+                        }}
+                    >
                         <SelectTrigger className="w-32">
                             <SelectValue />
                         </SelectTrigger>
@@ -74,10 +91,26 @@ export default function LeaderboardClient() {
                 <div className="flex items-center justify-between gap-2 md:justify-start">
                     <span className="text-sm font-medium text-muted-foreground">Variant:</span>
                     <div className="flex rounded-md border border-border/60">
-                        <Button variant={selectedVariant === "classic" ? "default" : "ghost"} size="sm" onClick={() => setSelectedVariant("classic")} className="rounded-r-none border-r">
+                        <Button
+                            variant={selectedVariant === "classic" ? "default" : "ghost"}
+                            size="sm"
+                            onClick={() => {
+                                setSelectedVariant("classic");
+                                setPage(1);
+                            }}
+                            className="rounded-r-none border-r"
+                        >
                             {t.leaderboard.filters.variant.classic}
                         </Button>
-                        <Button variant={selectedVariant === "death" ? "destructive" : "ghost"} size="sm" onClick={() => setSelectedVariant("death")} className="rounded-l-none">
+                        <Button
+                            variant={selectedVariant === "death" ? "destructive" : "ghost"}
+                            size="sm"
+                            onClick={() => {
+                                setSelectedVariant("death");
+                                setPage(1);
+                            }}
+                            className="rounded-l-none"
+                        >
                             {t.leaderboard.filters.variant.death}
                         </Button>
                     </div>
@@ -107,7 +140,15 @@ export default function LeaderboardClient() {
                                 <th scope="col" className="px-2 py-3 text-left sm:px-6 sm:py-4">{t.leaderboard.table.player}</th>
                                 {selectedVariant === "classic" && (
                                     <th scope="col" className="hidden px-3 py-3 text-right sm:table-cell sm:px-6 sm:py-4">
-                                        <Button variant="ghost" size="sm" onClick={() => setOrderMetric("total")} className="h-auto p-0 font-semibold hover:bg-transparent">
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => {
+                                                setOrderMetric("total");
+                                                setPage(1);
+                                            }}
+                                            className="h-auto p-0 font-semibold hover:bg-transparent"
+                                        >
                                             {t.leaderboard.table.totalScore}
                                             {orderMetric === "total" && <ChevronDownIcon className="ml-1 h-3 w-3" />}
                                         </Button>
@@ -116,7 +157,15 @@ export default function LeaderboardClient() {
                                 <th scope="col" className="hidden px-6 py-4 text-right md:table-cell">{t.leaderboard.table.gamesPlayed}</th>
                                 <th scope="col" className="w-20 px-3 py-3 text-right text-xs sm:w-auto sm:px-6 sm:py-4 sm:text-base">
                                     {selectedVariant === "classic" ? (
-                                        <Button variant="ghost" size="sm" onClick={() => setOrderMetric("highest")} className="h-auto p-0 font-semibold hover:bg-transparent">
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => {
+                                                setOrderMetric("highest");
+                                                setPage(1);
+                                            }}
+                                            className="h-auto p-0 font-semibold hover:bg-transparent"
+                                        >
                                             {t.leaderboard.table.hiScore}
                                             {orderMetric === "highest" && <ChevronDownIcon className="ml-1 h-3 w-3" />}
                                         </Button>

--- a/src/app/user/[banchoId]/client.tsx
+++ b/src/app/user/[banchoId]/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Game, GameMode, UserAchievement, UserWithStats, UserRanks } from "@/actions/types";
 import { getUserByIdAction, getUserStatsAction, getUserLatestGamesAction, getUserTopGamesAction } from "@/actions/user-server";
 import Image from "next/image";
@@ -9,6 +9,7 @@ import { GameVariant } from "@/app/games/config";
 import { useTranslationsContext } from "@/context/translations-provider";
 import UserNotFound from "./NotFound";
 import { getHighestScore } from "@/lib/user-stats";
+import { createLatestRequestGate } from "@/lib/latest-request";
 
 interface GameStats {
     game_mode: GameMode;
@@ -36,8 +37,11 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
     const [topPlays, setTopPlays] = useState<Game[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+    const requestGate = useRef(createLatestRequestGate());
 
     useEffect(() => {
+        const request = requestGate.current.begin();
+
         const fetchUserData = async () => {
             try {
                 setIsLoading(true);
@@ -47,11 +51,12 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
                 const userData = await getUserByIdAction(Number(banchoId));
 
                 if (!userData) {
-                    setError("User not found");
+                    if (request.isCurrent()) {
+                        setUser(null);
+                        setError("User not found");
+                    }
                     return;
                 }
-
-                setUser(userData);
 
                 // Then fetch all other data in parallel
                 const [statsData, gamesData, topPlaysData] = await Promise.all([
@@ -60,23 +65,30 @@ export default function UserProfileClient({ currentMode, currentVariant, banchoI
                     getUserTopGamesAction(Number(banchoId), undefined, currentVariant),
                 ]);
 
-                setUserStats(statsData);
-
                 const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
                 const filteredGames = gamesData.filter((x) => new Date(x.ended_at) > twentyFourHoursAgo);
-                setUserGames(filteredGames);
 
-                setTopPlays(topPlaysData);
+                if (request.isCurrent()) {
+                    setUser(userData);
+                    setUserStats(statsData);
+                    setUserGames(filteredGames);
+                    setTopPlays(topPlaysData);
+                }
             } catch (err) {
-                console.error("Failed to fetch user data:", err);
-                setError(err instanceof Error ? err.message : "Failed to load user data");
+                if (request.isCurrent()) {
+                    console.error("Failed to fetch user data:", err);
+                    setError(err instanceof Error ? err.message : "Failed to load user data");
+                }
             } finally {
-                setIsLoading(false);
+                if (request.isCurrent()) {
+                    setIsLoading(false);
+                }
             }
         };
 
-        fetchUserData();
-    }, [banchoId, currentVariant]);
+        void fetchUserData();
+        return () => request.cancel();
+    }, [banchoId, currentMode, currentVariant]);
 
     if (isLoading) {
         return <UserProfileSkeleton currentMode={currentMode} currentVariant={currentVariant} banchoId={banchoId} />;

--- a/src/components/UserSearch.tsx
+++ b/src/components/UserSearch.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { Input } from "@/components/ui/input";
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } 
 import { VisuallyHidden } from "@/components/ui/visually-hidden";
 import { searchUsersAction } from "@/actions/user-server";
 import { useTranslationsContext } from "@/context/translations-provider";
+import { createLatestRequestGate } from "@/lib/latest-request";
 
 interface SearchResult {
     bancho_id: number;
@@ -23,6 +24,7 @@ export default function UserSearch() {
     const [query, setQuery] = useState("");
     const [results, setResults] = useState<SearchResult[]>([]);
     const [isSearching, setIsSearching] = useState(false);
+    const requestGate = useRef(createLatestRequestGate());
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -37,24 +39,40 @@ export default function UserSearch() {
     }, []);
 
     useEffect(() => {
+        const request = requestGate.current.begin();
+
+        if (query.length < 2) {
+            setResults([]);
+            setIsSearching(false);
+            return () => request.cancel();
+        }
+
         const delayDebounceFn = setTimeout(async () => {
-            if (query.length >= 2) {
+            if (request.isCurrent()) {
                 setIsSearching(true);
-                try {
-                    const searchResults = await searchUsersAction(query);
+            }
+
+            try {
+                const searchResults = await searchUsersAction(query);
+                if (request.isCurrent()) {
                     setResults(searchResults);
-                } catch (error) {
+                }
+            } catch (error) {
+                if (request.isCurrent()) {
                     console.error("Search failed:", error);
                     setResults([]);
-                } finally {
+                }
+            } finally {
+                if (request.isCurrent()) {
                     setIsSearching(false);
                 }
-            } else {
-                setResults([]);
             }
         }, 300);
 
-        return () => clearTimeout(delayDebounceFn);
+        return () => {
+            clearTimeout(delayDebounceFn);
+            request.cancel();
+        };
     }, [query]);
 
     const handleSelect = () => {

--- a/src/lib/latest-request.test.ts
+++ b/src/lib/latest-request.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { createLatestRequestGate, RequestToken } from "./latest-request";
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolver, rejecter) => {
+        resolve = resolver;
+        reject = rejecter;
+    });
+    return { promise, resolve, reject };
+}
+
+describe("createLatestRequestGate", () => {
+    test("prevents an older response from committing after a newer response", async () => {
+        const gate = createLatestRequestGate();
+        const oldResponse = deferred<string>();
+        const newResponse = deferred<string>();
+        const committed: string[] = [];
+
+        const commitWhenCurrent = async (promise: Promise<string>, request: RequestToken) => {
+            const value = await promise;
+            if (request.isCurrent()) committed.push(value);
+        };
+
+        const oldCommit = commitWhenCurrent(oldResponse.promise, gate.begin());
+        const newCommit = commitWhenCurrent(newResponse.promise, gate.begin());
+
+        newResponse.resolve("new");
+        await newCommit;
+        oldResponse.resolve("old");
+        await oldCommit;
+
+        expect(committed).toEqual(["new"]);
+    });
+
+    test("invalidates an active request during cleanup", () => {
+        const request = createLatestRequestGate().begin();
+        request.cancel();
+        expect(request.isCurrent()).toBe(false);
+    });
+
+    test("prevents a stale rejection and finalizer from changing current state", async () => {
+        const gate = createLatestRequestGate();
+        const oldResponse = deferred<string>();
+        const oldRequest = gate.begin();
+        const state = { error: "", loading: true };
+
+        const oldCompletion = oldResponse.promise
+            .catch(() => {
+                if (oldRequest.isCurrent()) state.error = "old failure";
+            })
+            .finally(() => {
+                if (oldRequest.isCurrent()) state.loading = false;
+            });
+
+        gate.begin();
+        oldResponse.reject(new Error("stale"));
+        await oldCompletion;
+
+        expect(state).toEqual({ error: "", loading: true });
+    });
+});

--- a/src/lib/latest-request.ts
+++ b/src/lib/latest-request.ts
@@ -1,0 +1,23 @@
+export interface RequestToken {
+    isCurrent(): boolean;
+    cancel(): void;
+}
+
+export function createLatestRequestGate() {
+    let activeRequest = 0;
+
+    return {
+        begin(): RequestToken {
+            const requestId = ++activeRequest;
+
+            return {
+                isCurrent: () => requestId === activeRequest,
+                cancel: () => {
+                    if (requestId === activeRequest) {
+                        activeRequest += 1;
+                    }
+                },
+            };
+        },
+    };
+}


### PR DESCRIPTION
Client-side data consumers ignore superseded asynchronous responses, so older requests cannot overwrite newer filters, queries, suggestions, profiles, errors, announcements, or loading state.

- rebases the request guards onto the accessibility and responsive implementation already merged through PR #36
- preserves `GuessInput` combobox/listbox semantics, active descendants, option selection state, live announcements, and existing keyboard shortcuts
- commits suggestion results, visibility, selection, and translated announcements only for the current request
- keeps stale suggestion successes, failures, logs, and finalizers from changing current state
- preserves the responsive leaderboard table and narrow loading/error/empty states while guarding active data, errors, and loading
- resets leaderboard pagination for mode, variant, ordering, and page-size changes
- preserves user-search dialog/search/live-region semantics while guarding search results and loading
- commits profile data as one current-response snapshot
- tests out-of-order success, cleanup invalidation, and stale rejection/finalization

**Tests**

- `bun install --frozen-lockfile` — passed, no lockfile changes
- `bun run check` — passed
- `bun test` — passed (58 tests)
- `bun run build` — passed

**Conflict resolution**

Conflicts in `GuessInput.tsx`, the leaderboard client, and the profile client were resolved by retaining current `main` behavior from PRs #35/#36 and layering the request-generation guard onto it.

**Remaining limitations**

- Server Actions cannot be cancelled by these clients, so superseded server work may finish, but its response is ignored.
- The repository still has no component/DOM test dependency; ARIA state preservation was verified through source review, lint, TypeScript, unit tests, and the production build.