### PR TITLE
fix(api): validate parameters and map error statuses

### DIFF
--- a/src/actions/api-keys-server.ts
+++ b/src/actions/api-keys-server.ts
@@ -4,14 +4,11 @@ import { authenticatedAction } from "./server";
 import { query } from "@/lib/database";
 import redisClient from "@/lib/redis";
 import crypto from "crypto";
+import { validateApiKeyValue } from "@/lib/api/key-validation";
 
 import type { ApiKey } from "./types";
 
 export type { ApiKey };
-
-const API_RATE_LIMIT_WINDOW_SECONDS = 60;
-const API_RATE_LIMIT_MAX_REQUESTS = 120;
-const API_LAST_USED_UPDATE_INTERVAL_MS = 5 * 60 * 1000;
 
 function hashApiKey(apiKey: string): string {
     return crypto.createHash("sha256").update(apiKey).digest("hex");
@@ -59,31 +56,8 @@ export async function deleteApiKeyAction(keyId: string): Promise<void> {
 }
 
 export async function validateApiKey(apiKey?: string | null): Promise<number> {
-    if (!apiKey) {
-        throw new Error("API key was not provided.");
-    }
-
-    const hashedKey = hashApiKey(apiKey);
-    const [key] = (await query(`SELECT user_id, last_used FROM api_keys WHERE id = ?`, [hashedKey])) as [{ user_id: number; last_used: Date | string | null }];
-
-    if (!key) {
-        throw new Error("Invalid API key");
-    }
-
-    const rateLimitKey = `api_key_rate:${hashedKey}`;
-    const requestCount = await redisClient.incr(rateLimitKey);
-    if (requestCount === 1) {
-        await redisClient.expire(rateLimitKey, API_RATE_LIMIT_WINDOW_SECONDS);
-    }
-
-    if (requestCount > API_RATE_LIMIT_MAX_REQUESTS) {
-        throw new Error("Rate limit exceeded");
-    }
-
-    const lastUsed = key.last_used ? new Date(key.last_used).getTime() : 0;
-    if (!lastUsed || Date.now() - lastUsed >= API_LAST_USED_UPDATE_INTERVAL_MS) {
-        await query(`UPDATE api_keys SET last_used = CURRENT_TIMESTAMP WHERE id = ?`, [hashedKey]);
-    }
-
-    return key.user_id;
+    return validateApiKeyValue(apiKey, {
+        query: (sql, values) => query(sql, values),
+        redis: redisClient,
+    });
 }

--- a/src/app/api/games/leaderboard/route.ts
+++ b/src/app/api/games/leaderboard/route.ts
@@ -3,11 +3,12 @@ import { validateApiKey } from "@/actions/api-keys-server";
 import { getTopPlayersAction } from "@/actions/user-server";
 import { GameMode } from "@/actions/types";
 import { z } from "zod";
+import { apiErrorResponse } from "@/lib/api/errors";
 
 const querySchema = z.object({
     mode: z.nativeEnum(GameMode).default(GameMode.Background),
     variant: z.enum(["classic", "death"]).default("classic"),
-    limit: z.coerce.number().min(1).max(100).default(100),
+    limit: z.coerce.number().int().min(1).max(100).default(100),
 });
 
 export async function GET(request: Request) {
@@ -16,16 +17,11 @@ export async function GET(request: Request) {
 
     try {
         await validateApiKey(apiKey);
-    } catch {
-        return NextResponse.json({ success: false, error: "Invalid API key" }, { status: 403 });
-    }
-
-    try {
         const { searchParams } = new URL(request.url);
         const query = querySchema.parse({
-            mode: searchParams.get("mode"),
-            variant: searchParams.get("variant"),
-            limit: Number(searchParams.get("limit")),
+            mode: searchParams.get("mode") ?? undefined,
+            variant: searchParams.get("variant") ?? undefined,
+            limit: searchParams.get("limit") ?? undefined,
         });
 
         const leaderboard = await getTopPlayersAction(query.mode, query.variant, query.limit);
@@ -35,7 +31,6 @@ export async function GET(request: Request) {
             data: leaderboard,
         });
     } catch (error) {
-        console.error("Leaderboard error:", error);
-        return NextResponse.json({ success: false, error: "Failed to fetch leaderboard" }, { status: 500 });
+        return apiErrorResponse(error, "Failed to fetch leaderboard", "Leaderboard error");
     }
 }

--- a/src/app/api/routes.test.ts
+++ b/src/app/api/routes.test.ts
@@ -1,0 +1,126 @@
+import { beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { ApiRateLimitError, ApiValidationServiceError, InvalidApiKeyError, MissingApiKeyError } from "@/lib/api/errors";
+import { GameMode } from "@/actions/types";
+
+const validateApiKeyMock = mock(async () => 123);
+const getTopPlayersMock = mock(async () => []);
+const searchUsersMock = mock(async () => []);
+const getUserByIdMock = mock(async () => ({ bancho_id: 123 }));
+const getUserStatsMock = mock(async () => []);
+const getUserLatestGamesMock = mock(async () => []);
+const getUserGamesCountMock = mock(async () => 0);
+const getHighestStatsMock = mock(async () => ({}));
+
+mock.module("@/actions/api-keys-server", () => ({ validateApiKey: validateApiKeyMock }));
+mock.module("@/actions/user-server", () => ({
+    getTopPlayersAction: getTopPlayersMock,
+    searchUsersAction: searchUsersMock,
+    getUserByIdAction: getUserByIdMock,
+    getUserStatsAction: getUserStatsMock,
+    getUserLatestGamesAction: getUserLatestGamesMock,
+    getUserGamesCountAction: getUserGamesCountMock,
+    getHighestStatsAction: getHighestStatsMock,
+}));
+
+type RouteHandler = (request: Request) => Promise<Response>;
+type UserRouteHandler = (request: Request, context: { params: Promise<{ userId: string }> }) => Promise<Response>;
+
+let leaderboardGet: RouteHandler;
+let searchGet: RouteHandler;
+let userGet: UserRouteHandler;
+let userStatsGet: UserRouteHandler;
+let userGamesGet: UserRouteHandler;
+
+const request = (path: string, withKey = true) =>
+    new Request(`http://localhost${path}`, {
+        headers: withKey ? { "X-API-Key": "test-key" } : undefined,
+    });
+
+beforeAll(async () => {
+    [
+        { GET: leaderboardGet },
+        { GET: searchGet },
+        { GET: userGet },
+        { GET: userStatsGet },
+        { GET: userGamesGet },
+    ] = await Promise.all([
+        import("./games/leaderboard/route"),
+        import("./users/search/route"),
+        import("./users/[userId]/route"),
+        import("./users/[userId]/stats/route"),
+        import("./users/[userId]/games/route"),
+    ]);
+});
+
+beforeEach(() => {
+    for (const mockedFunction of [validateApiKeyMock, getTopPlayersMock, searchUsersMock, getUserByIdMock, getUserStatsMock, getUserLatestGamesMock, getUserGamesCountMock, getHighestStatsMock]) {
+        mockedFunction.mockClear();
+    }
+    validateApiKeyMock.mockImplementation(async () => 123);
+});
+
+describe("API route parameter defaults", () => {
+    test("uses leaderboard schema defaults when parameters are omitted", async () => {
+        const response = await leaderboardGet(request("/api/games/leaderboard"));
+        expect(response.status).toBe(200);
+        expect(getTopPlayersMock).toHaveBeenCalledWith(GameMode.Background, "classic", 100);
+    });
+
+    test("uses the user-search limit default when it is omitted", async () => {
+        const response = await searchGet(request("/api/users/search?query=player"));
+        expect(response.status).toBe(200);
+        expect(searchUsersMock).toHaveBeenCalledWith("player", 20);
+    });
+
+    test("uses game pagination and variant defaults when they are omitted", async () => {
+        const response = await userGamesGet(request("/api/users/123/games"), { params: Promise.resolve({ userId: "123" }) });
+        expect(response.status).toBe(200);
+        expect(getUserLatestGamesMock).toHaveBeenCalledWith(123, undefined, "classic", 20, 0);
+        expect(getUserGamesCountMock).toHaveBeenCalledWith(123, undefined, "classic");
+    });
+
+    test("allows an omitted optional user-stats mode", async () => {
+        const response = await userStatsGet(request("/api/users/123/stats"), { params: Promise.resolve({ userId: "123" }) });
+        expect(response.status).toBe(200);
+        expect(getUserStatsMock).toHaveBeenCalledWith(123);
+    });
+});
+
+describe("API route validation and authentication responses", () => {
+    test("returns 400 for malformed query values", async () => {
+        const response = await leaderboardGet(request("/api/games/leaderboard?limit=invalid"));
+        expect(response.status).toBe(400);
+        expect(getTopPlayersMock).not.toHaveBeenCalled();
+    });
+
+    test("returns 400 for non-positive or malformed user IDs", async () => {
+        const zeroResponse = await userGamesGet(request("/api/users/0/games"), { params: Promise.resolve({ userId: "0" }) });
+        const malformedResponse = await userGet(request("/api/users/nope"), { params: Promise.resolve({ userId: "nope" }) });
+        expect(zeroResponse.status).toBe(400);
+        expect(malformedResponse.status).toBe(400);
+    });
+
+    test.each([
+        [new MissingApiKeyError(), 401],
+        [new InvalidApiKeyError(), 403],
+        [new ApiRateLimitError(), 429],
+        [new ApiValidationServiceError(), 503],
+    ])("maps an API key failure to its expected status", async (error, status) => {
+        validateApiKeyMock.mockImplementationOnce(async () => {
+            throw error;
+        });
+        const response = await leaderboardGet(request("/api/games/leaderboard", !(error instanceof MissingApiKeyError)));
+        expect(response.status).toBe(status);
+    });
+
+    test("returns 500 for an unexpected validation failure instead of invalid-key 403", async () => {
+        const consoleError = spyOn(console, "error").mockImplementation(() => {});
+        validateApiKeyMock.mockImplementationOnce(async () => {
+            throw new Error("unexpected dependency failure");
+        });
+        const response = await leaderboardGet(request("/api/games/leaderboard"));
+        expect(response.status).toBe(500);
+        expect(await response.json()).toEqual({ success: false, error: "Failed to fetch leaderboard" });
+        consoleError.mockRestore();
+    });
+});

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { validateApiKey } from "@/actions/api-keys-server";
 import { getHighestStatsAction } from "@/actions/user-server";
 import { z } from "zod";
+import { apiErrorResponse } from "@/lib/api/errors";
 
 const querySchema = z.object({
     variant: z.enum(["classic", "death"]).default("classic"),
@@ -13,14 +14,9 @@ export async function GET(request: Request) {
 
     try {
         await validateApiKey(apiKey);
-    } catch {
-        return NextResponse.json({ success: false, error: "Invalid API key" }, { status: 403 });
-    }
-
-    try {
         const { searchParams } = new URL(request.url);
         const query = querySchema.parse({
-            variant: searchParams.get("variant") || "classic",
+            variant: searchParams.get("variant") ?? undefined,
         });
 
         const stats = await getHighestStatsAction(query.variant);
@@ -30,7 +26,6 @@ export async function GET(request: Request) {
             data: stats,
         });
     } catch (error) {
-        console.error("Stats error:", error);
-        return NextResponse.json({ success: false, error: "Failed to fetch stats" }, { status: 500 });
+        return apiErrorResponse(error, "Failed to fetch stats", "Stats error");
     }
 }

--- a/src/app/api/users/[userId]/games/route.ts
+++ b/src/app/api/users/[userId]/games/route.ts
@@ -3,13 +3,15 @@ import { validateApiKey } from "@/actions/api-keys-server";
 import { getUserGamesCountAction, getUserLatestGamesAction } from "@/actions/user-server";
 import { GameMode } from "@/actions/types";
 import { z } from "zod";
+import { apiErrorResponse } from "@/lib/api/errors";
 
 const querySchema = z.object({
     mode: z.nativeEnum(GameMode).optional(),
     variant: z.enum(["classic", "death"]).default("classic"),
-    limit: z.coerce.number().min(1).max(100).default(20),
-    offset: z.coerce.number().min(0).default(0),
+    limit: z.coerce.number().int().min(1).max(100).default(20),
+    offset: z.coerce.number().int().min(0).default(0),
 });
+const userIdSchema = z.coerce.number().int().positive();
 
 export async function GET(request: Request, { params }: { params: Promise<{ userId: string }> }) {
     const headers = new Headers(request.headers);
@@ -17,21 +19,16 @@ export async function GET(request: Request, { params }: { params: Promise<{ user
 
     try {
         await validateApiKey(apiKey);
-    } catch {
-        return NextResponse.json({ success: false, error: "Invalid API key" }, { status: 403 });
-    }
-
-    try {
         const { userId } = await params;
         const { searchParams } = new URL(request.url);
         const query = querySchema.parse({
-            mode: searchParams.get("mode"),
-            variant: searchParams.get("variant") || "classic",
+            mode: searchParams.get("mode") ?? undefined,
+            variant: searchParams.get("variant") ?? undefined,
             limit: searchParams.get("limit") ?? undefined,
             offset: searchParams.get("offset") ?? undefined,
         });
 
-        const banchoId = Number(userId);
+        const banchoId = userIdSchema.parse(userId);
         const [games, total] = await Promise.all([getUserLatestGamesAction(banchoId, query.mode, query.variant, query.limit, query.offset), getUserGamesCountAction(banchoId, query.mode, query.variant)]);
 
         return NextResponse.json({
@@ -44,7 +41,6 @@ export async function GET(request: Request, { params }: { params: Promise<{ user
             },
         });
     } catch (error) {
-        console.error("Games error:", error);
-        return NextResponse.json({ success: false, error: "Failed to fetch user games" }, { status: 500 });
+        return apiErrorResponse(error, "Failed to fetch user games", "Games error");
     }
 }

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
 import { validateApiKey } from "@/actions/api-keys-server";
 import { getUserByIdAction } from "@/actions/user-server";
+import { z } from "zod";
+import { apiErrorResponse } from "@/lib/api/errors";
+
+const userIdSchema = z.coerce.number().int().positive();
 
 export async function GET(request: Request, { params }: { params: Promise<{ userId: string }> }) {
     const headers = new Headers(request.headers);
@@ -8,13 +12,8 @@ export async function GET(request: Request, { params }: { params: Promise<{ user
 
     try {
         await validateApiKey(apiKey);
-    } catch {
-        return NextResponse.json({ success: false, error: "Invalid API key" }, { status: 403 });
-    }
-
-    try {
         const { userId } = await params;
-        const user = await getUserByIdAction(Number(userId));
+        const user = await getUserByIdAction(userIdSchema.parse(userId));
 
         if (!user) {
             return NextResponse.json({ success: false, error: "User not found" }, { status: 404 });
@@ -25,7 +24,6 @@ export async function GET(request: Request, { params }: { params: Promise<{ user
             data: user,
         });
     } catch (error) {
-        console.error("User fetch error:", error);
-        return NextResponse.json({ success: false, error: "Failed to fetch user" }, { status: 500 });
+        return apiErrorResponse(error, "Failed to fetch user", "User fetch error");
     }
 }

--- a/src/app/api/users/[userId]/stats/route.ts
+++ b/src/app/api/users/[userId]/stats/route.ts
@@ -2,10 +2,12 @@ import { NextResponse } from "next/server";
 import { validateApiKey } from "@/actions/api-keys-server";
 import { getUserStatsAction } from "@/actions/user-server";
 import { z } from "zod";
+import { apiErrorResponse } from "@/lib/api/errors";
 
 const querySchema = z.object({
     mode: z.enum(["background", "audio", "skin"]).optional(),
 });
+const userIdSchema = z.coerce.number().int().positive();
 
 export async function GET(request: Request, { params }: { params: Promise<{ userId: string }> }) {
     const headers = new Headers(request.headers);
@@ -13,18 +15,14 @@ export async function GET(request: Request, { params }: { params: Promise<{ user
 
     try {
         await validateApiKey(apiKey);
-    } catch {
-        return NextResponse.json({ success: false, error: "Invalid API key" }, { status: 403 });
-    }
-
-    try {
         const { userId } = await params;
+        const banchoId = userIdSchema.parse(userId);
         const { searchParams } = new URL(request.url);
         const query = querySchema.parse({
-            mode: searchParams.get("mode"),
+            mode: searchParams.get("mode") ?? undefined,
         });
 
-        const stats = await getUserStatsAction(Number(userId));
+        const stats = await getUserStatsAction(banchoId);
         const filteredStats = query.mode ? stats.filter((s) => s.game_mode === query.mode) : stats;
 
         return NextResponse.json({
@@ -32,7 +30,6 @@ export async function GET(request: Request, { params }: { params: Promise<{ user
             data: filteredStats,
         });
     } catch (error) {
-        console.error("Stats error:", error);
-        return NextResponse.json({ success: false, error: "Failed to fetch user stats" }, { status: 500 });
+        return apiErrorResponse(error, "Failed to fetch user stats", "Stats error");
     }
 }

--- a/src/app/api/users/search/route.ts
+++ b/src/app/api/users/search/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from "next/server";
 import { searchUsersAction } from "@/actions/user-server";
 import { z } from "zod";
 import { validateApiKey } from "@/actions/api-keys-server";
+import { apiErrorResponse } from "@/lib/api/errors";
 
 const querySchema = z.object({
     query: z.string().min(2).max(250),
-    limit: z.coerce.number().min(1).max(100).default(20),
+    limit: z.coerce.number().int().min(1).max(100).default(20),
 });
 
 export async function GET(request: Request) {
@@ -14,15 +15,10 @@ export async function GET(request: Request) {
 
     try {
         await validateApiKey(apiKey);
-    } catch {
-        return NextResponse.json({ success: false, error: "Invalid API key" }, { status: 403 });
-    }
-
-    try {
         const { searchParams } = new URL(request.url);
         const validated = querySchema.parse({
             query: searchParams.get("query") || "",
-            limit: Number(searchParams.get("limit")),
+            limit: searchParams.get("limit") ?? undefined,
         });
 
         const users = await searchUsersAction(validated.query, validated.limit);
@@ -32,7 +28,6 @@ export async function GET(request: Request) {
             data: users,
         });
     } catch (error) {
-        console.error("User search error:", error);
-        return NextResponse.json({ success: false, error: "Failed to search users" }, { status: 500 });
+        return apiErrorResponse(error, "Failed to search users", "User search error");
     }
 }

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+
+export class ApiError extends Error {
+    constructor(
+        message: string,
+        readonly status: number
+    ) {
+        super(message);
+        this.name = new.target.name;
+    }
+}
+
+export class MissingApiKeyError extends ApiError {
+    constructor() {
+        super("API key was not provided", 401);
+    }
+}
+
+export class InvalidApiKeyError extends ApiError {
+    constructor() {
+        super("Invalid API key", 403);
+    }
+}
+
+export class ApiRateLimitError extends ApiError {
+    constructor() {
+        super("Rate limit exceeded", 429);
+    }
+}
+
+export class ApiValidationServiceError extends ApiError {
+    constructor() {
+        super("API key validation is temporarily unavailable", 503);
+    }
+}
+
+export function apiErrorResponse(error: unknown, fallbackMessage: string, logLabel: string) {
+    if (error instanceof ZodError) {
+        return NextResponse.json({ success: false, error: "Invalid request parameters" }, { status: 400 });
+    }
+
+    if (error instanceof ApiError) {
+        return NextResponse.json({ success: false, error: error.message }, { status: error.status });
+    }
+
+    console.error(`${logLabel}:`, error);
+    return NextResponse.json({ success: false, error: fallbackMessage }, { status: 500 });
+}

--- a/src/lib/api/key-validation.test.ts
+++ b/src/lib/api/key-validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { ApiRateLimitError, ApiValidationServiceError, InvalidApiKeyError, MissingApiKeyError } from "./errors";
+import { validateApiKeyValue } from "./key-validation";
+
+const validKeyRow = { user_id: 123, last_used: new Date() };
+
+function dependencies({ row = validKeyRow, requestCount = 1, queryError, redisError }: { row?: typeof validKeyRow | null; requestCount?: number; queryError?: Error; redisError?: Error } = {}) {
+    return {
+        query: async (sql: string) => {
+            if (queryError) throw queryError;
+            return sql.startsWith("SELECT") && row ? [row] : [];
+        },
+        redis: {
+            incr: async () => {
+                if (redisError) throw redisError;
+                return requestCount;
+            },
+            expire: async () => 1,
+        },
+    };
+}
+
+describe("validateApiKeyValue", () => {
+    test("distinguishes missing, invalid, and rate-limited keys", async () => {
+        await expect(validateApiKeyValue(undefined, dependencies())).rejects.toBeInstanceOf(MissingApiKeyError);
+        await expect(validateApiKeyValue("invalid", dependencies({ row: null }))).rejects.toBeInstanceOf(InvalidApiKeyError);
+        await expect(validateApiKeyValue("limited", dependencies({ requestCount: 121 }))).rejects.toBeInstanceOf(ApiRateLimitError);
+    });
+
+    test("maps database and Redis failures to a validation service error", async () => {
+        const consoleError = spyOn(console, "error").mockImplementation(() => {});
+        await expect(validateApiKeyValue("key", dependencies({ queryError: new Error("database unavailable") }))).rejects.toBeInstanceOf(ApiValidationServiceError);
+        await expect(validateApiKeyValue("key", dependencies({ redisError: new Error("redis unavailable") }))).rejects.toBeInstanceOf(ApiValidationServiceError);
+        consoleError.mockRestore();
+    });
+});

--- a/src/lib/api/key-validation.ts
+++ b/src/lib/api/key-validation.ts
@@ -1,0 +1,64 @@
+import crypto from "crypto";
+import { ApiError, ApiRateLimitError, ApiValidationServiceError, InvalidApiKeyError, MissingApiKeyError } from "./errors";
+
+const API_RATE_LIMIT_WINDOW_SECONDS = 60;
+const API_RATE_LIMIT_MAX_REQUESTS = 120;
+const API_LAST_USED_UPDATE_INTERVAL_MS = 5 * 60 * 1000;
+
+type QueryFunction = (sql: string, values?: Array<unknown>) => Promise<unknown[]>;
+
+interface RateLimitClient {
+    incr(key: string): Promise<number>;
+    expire(key: string, seconds: number): Promise<unknown>;
+}
+
+interface ApiKeyValidationDependencies {
+    query: QueryFunction;
+    redis: RateLimitClient;
+    now?: () => number;
+}
+
+function hashApiKey(apiKey: string): string {
+    return crypto.createHash("sha256").update(apiKey).digest("hex");
+}
+
+export async function validateApiKeyValue(apiKey: string | null | undefined, dependencies: ApiKeyValidationDependencies): Promise<number> {
+    if (!apiKey) {
+        throw new MissingApiKeyError();
+    }
+
+    const hashedKey = hashApiKey(apiKey);
+
+    try {
+        const [key] = (await dependencies.query(`SELECT user_id, last_used FROM api_keys WHERE id = ?`, [hashedKey])) as [{ user_id: number; last_used: Date | string | null }?];
+
+        if (!key) {
+            throw new InvalidApiKeyError();
+        }
+
+        const rateLimitKey = `api_key_rate:${hashedKey}`;
+        const requestCount = await dependencies.redis.incr(rateLimitKey);
+        if (requestCount === 1) {
+            await dependencies.redis.expire(rateLimitKey, API_RATE_LIMIT_WINDOW_SECONDS);
+        }
+
+        if (requestCount > API_RATE_LIMIT_MAX_REQUESTS) {
+            throw new ApiRateLimitError();
+        }
+
+        const now = dependencies.now?.() ?? Date.now();
+        const lastUsed = key.last_used ? new Date(key.last_used).getTime() : 0;
+        if (!lastUsed || now - lastUsed >= API_LAST_USED_UPDATE_INTERVAL_MS) {
+            await dependencies.query(`UPDATE api_keys SET last_used = CURRENT_TIMESTAMP WHERE id = ?`, [hashedKey]);
+        }
+
+        return key.user_id;
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error;
+        }
+
+        console.error("API key validation failed:", error);
+        throw new ApiValidationServiceError();
+    }
+}


### PR DESCRIPTION
Public API routes now preserve schema defaults for omitted values, reject malformed inputs consistently, and return authentication/dependency statuses that match the actual failure.

- Passes absent optional query parameters as `undefined` instead of `null` or numeric zero.
- Validates limits and offsets as integers and user IDs as positive integers.
- Maps Zod failures to 400.
- Returns 401 for missing keys, 403 for invalid keys, 429 for rate limits, and 503 for database/Redis failures during key validation.
- Keeps unexpected route failures generic at 500 without exposing internal errors.
- Covers leaderboard, search, user, user stats, user games, and aggregate stats routes.
- Adds route-level default/status tests plus focused key-validation dependency tests.

Tests:
- `bun run check` — passed.
- `bun test` — passed (48 tests).
- `bun run build` — passed.

Remaining limitations:
- This PR does not change rate-limit policy, database query architecture, or public Server Action authentication.