### PR TITLE
fix(reports): make webhook delivery optional

### DIFF
--- a/src/actions/reports-server.ts
+++ b/src/actions/reports-server.ts
@@ -1,37 +1,18 @@
 "use server";
 
-import { z } from "zod";
 import { query } from "@/lib/database";
 import { authenticatedAction } from "./server";
 import { ReportType, Report } from "./types";
 import redisClient from "@/lib/redis";
 
 import { env } from "@/lib/env";
+import { reportSchema } from "@/lib/report-validation";
+import { createReportRecord } from "@/lib/report-service";
 
 export type { ReportType };
 
-const DISCORD_WEBHOOK_URL = env.DISCORD_WEBHOOK!;
 const REPORT_RATE_LIMIT_WINDOW_SECONDS = 10 * 60;
 const REPORT_RATE_LIMIT_MAX_REQUESTS = 3;
-
-const reportSchema = z.object({
-    mapsetId: z.number(),
-    reportType: z.enum(["incorrect_title", "inappropriate_content", "wrong_audio", "wrong_background", "other"]),
-    description: z.string().min(10).max(1000),
-});
-
-async function sendDiscordWebhook(content: string) {
-    await fetch(DISCORD_WEBHOOK_URL, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-            content,
-            allowed_mentions: { parse: [] },
-        }),
-    });
-}
 
 async function enforceReportRateLimit(userId: number) {
     const key = `report_rate:${userId}`;
@@ -45,41 +26,22 @@ async function enforceReportRateLimit(userId: number) {
     }
 }
 
-function escapeDiscordMentions(value: string): string {
-    return value.replace(/@/g, "@\u200b");
-}
-
 export async function createReportAction(mapsetId: number, reportType: ReportType, description: string): Promise<void> {
     return authenticatedAction(async (session) => {
-        await enforceReportRateLimit(session.user.banchoId);
         const validated = reportSchema.parse({
             mapsetId,
             reportType,
             description,
         });
+        await enforceReportRateLimit(session.user.banchoId);
 
-        const [mapset] = (await query(`SELECT title, artist FROM mapset_data WHERE mapset_id = ?`, [validated.mapsetId])) as [{ title: string; artist: string }];
-
-        const reportMessage = `
-**New Report**
-Type: ${reportType}
-Mapset: ${mapset.artist} - ${mapset.title}
-Mapset ID: ${mapsetId}
-Reported By: ${session.user.banchoId}
-
-Description:
-${escapeDiscordMentions(validated.description)}
-
-Mapset Link: https://osu.ppy.sh/s/${validated.mapsetId}
-`;
-
-        await sendDiscordWebhook(reportMessage);
-
-        await query(
-            `INSERT INTO reports (
-                user_id, mapset_id, report_type, description
-            ) VALUES (?, ?, ?, ?)`,
-            [session.user.banchoId, validated.mapsetId, validated.reportType, validated.description]
+        await createReportRecord(
+            { ...validated, userId: session.user.banchoId },
+            {
+                query: (sql, values) => query(sql, values),
+                webhookUrl: env.DISCORD_WEBHOOK,
+                logError: (message) => console.error(message),
+            }
         );
     });
 }

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -5,7 +5,7 @@ export enum GameMode {
 }
 export type GameVariant = "classic" | "death";
 export type ReportType = "incorrect_title" | "inappropriate_content" | "wrong_audio" | "wrong_background" | "other";
-type ReportStatus = "pending" | "investigating" | "resolved" | "rejected";
+export type ReportStatus = "pending" | "investigating" | "resolved" | "rejected";
 
 export interface ApiKey {
     id: string;

--- a/src/app/admin/actions/reports.ts
+++ b/src/app/admin/actions/reports.ts
@@ -3,6 +3,7 @@
 import { query } from "@/lib/database";
 import { Report } from "@/actions/types";
 import { requireOwner } from "@/actions/require-owner";
+import { reportStatusUpdateSchema } from "@/lib/report-validation";
 
 export async function listReports(): Promise<Report[]> {
     try {
@@ -31,8 +32,9 @@ export async function listReports(): Promise<Report[]> {
 export async function updateReportStatus(reportId: number, status: string): Promise<void> {
     try {
         await requireOwner();
-        await query(`UPDATE reports SET status = ? WHERE id = ?`, [status, reportId]);
-        console.log(`Report ${reportId} status updated to ${status}`);
+        const validated = reportStatusUpdateSchema.parse({ reportId, status });
+        await query(`UPDATE reports SET status = ? WHERE id = ?`, [validated.status, validated.reportId]);
+        console.log(`Report ${validated.reportId} status updated to ${validated.status}`);
     } catch (error) {
         console.error(`Error updating report ${reportId}:`, error);
         throw error;

--- a/src/lib/report-service.test.ts
+++ b/src/lib/report-service.test.ts
@@ -51,6 +51,32 @@ describe("createReportRecord", () => {
         expect(loggedErrors.join(" ")).not.toContain(webhookUrl);
     });
 
+    test("bounds webhook delivery and aborts it without failing the stored report", async () => {
+        let stored = false;
+        let deliverySignal: AbortSignal | null | undefined;
+        const loggedErrors: string[] = [];
+
+        await createReportRecord(validReport, {
+            query: async (sql) => {
+                if (sql.startsWith("SELECT")) return [{ title: "Title", artist: "Artist" }];
+                stored = true;
+                return [];
+            },
+            webhookUrl: "https://discord.example/private-webhook",
+            webhookTimeoutMs: 5,
+            fetchImpl: async (_input, init) => {
+                expect(stored).toBe(true);
+                deliverySignal = init?.signal;
+                return new Promise<Response>(() => {});
+            },
+            logError: (message) => loggedErrors.push(message),
+        });
+
+        expect(stored).toBe(true);
+        expect(deliverySignal?.aborted).toBe(true);
+        expect(loggedErrors).toEqual(["Report webhook delivery timed out"]);
+    });
+
     test("returns a controlled error when the mapset does not exist", async () => {
         let inserted = false;
 

--- a/src/lib/report-service.test.ts
+++ b/src/lib/report-service.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ZodError } from "zod";
+import { createReportRecord, ReportMapsetNotFoundError } from "./report-service";
+import { reportStatusUpdateSchema } from "./report-validation";
+
+const validReport = {
+    userId: 123,
+    mapsetId: 456,
+    reportType: "wrong_audio",
+    description: "The audio belongs to another mapset.",
+} as const;
+
+describe("createReportRecord", () => {
+    test("stores a report without attempting delivery when no webhook is configured", async () => {
+        const queries: string[] = [];
+        const fetchImpl = mock(async () => new Response(null, { status: 204 }));
+
+        await createReportRecord(validReport, {
+            query: async (sql) => {
+                queries.push(sql);
+                return sql.startsWith("SELECT") ? [{ title: "Title", artist: "Artist" }] : [];
+            },
+            fetchImpl,
+        });
+
+        expect(queries.some((sql) => sql.includes("INSERT INTO reports"))).toBe(true);
+        expect(fetchImpl).not.toHaveBeenCalled();
+    });
+
+    test("keeps the stored report when Discord returns an error", async () => {
+        let stored = false;
+        const loggedErrors: string[] = [];
+        const webhookUrl = "https://discord.example/private-webhook";
+
+        await createReportRecord(validReport, {
+            query: async (sql) => {
+                if (sql.startsWith("SELECT")) return [{ title: "Title", artist: "Artist" }];
+                stored = true;
+                return [];
+            },
+            webhookUrl,
+            fetchImpl: async () => {
+                expect(stored).toBe(true);
+                return new Response(null, { status: 503 });
+            },
+            logError: (message) => loggedErrors.push(message),
+        });
+
+        expect(stored).toBe(true);
+        expect(loggedErrors).toEqual(["Report webhook delivery failed with status 503"]);
+        expect(loggedErrors.join(" ")).not.toContain(webhookUrl);
+    });
+
+    test("returns a controlled error when the mapset does not exist", async () => {
+        let inserted = false;
+
+        await expect(
+            createReportRecord(validReport, {
+                query: async (sql) => {
+                    if (sql.includes("INSERT INTO reports")) inserted = true;
+                    return [];
+                },
+            })
+        ).rejects.toBeInstanceOf(ReportMapsetNotFoundError);
+
+        expect(inserted).toBe(false);
+    });
+
+    test("rejects an invalid report type before querying", async () => {
+        const query = mock(async () => []);
+
+        await expect(
+            createReportRecord(
+                { ...validReport, reportType: "not-a-report-type" },
+                { query }
+            )
+        ).rejects.toBeInstanceOf(ZodError);
+
+        expect(query).not.toHaveBeenCalled();
+    });
+});
+
+describe("reportStatusUpdateSchema", () => {
+    test("rejects invalid report IDs and statuses", () => {
+        expect(reportStatusUpdateSchema.safeParse({ reportId: 0, status: "pending" }).success).toBe(false);
+        expect(reportStatusUpdateSchema.safeParse({ reportId: 1, status: "deleted" }).success).toBe(false);
+        expect(reportStatusUpdateSchema.safeParse({ reportId: 1, status: "resolved" }).success).toBe(true);
+    });
+});

--- a/src/lib/report-service.ts
+++ b/src/lib/report-service.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { reportSchema } from "./report-validation";
+
+const storedReportSchema = reportSchema.extend({
+    userId: z.number().int().positive(),
+});
+
+type QueryFunction = (sql: string, values?: Array<unknown>) => Promise<unknown[]>;
+type FetchFunction = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+interface ReportDependencies {
+    query: QueryFunction;
+    webhookUrl?: string;
+    fetchImpl?: FetchFunction;
+    logError?: (message: string) => void;
+}
+
+export class ReportMapsetNotFoundError extends Error {
+    constructor() {
+        super("Mapset not found");
+        this.name = "ReportMapsetNotFoundError";
+    }
+}
+
+function escapeDiscordMentions(value: string): string {
+    return value.replace(/@/g, "@\u200b");
+}
+
+export async function createReportRecord(input: unknown, dependencies: ReportDependencies): Promise<void> {
+    const report = storedReportSchema.parse(input);
+    const [mapset] = (await dependencies.query(`SELECT title, artist FROM mapset_data WHERE mapset_id = ?`, [report.mapsetId])) as [{ title: string; artist: string }?];
+
+    if (!mapset) {
+        throw new ReportMapsetNotFoundError();
+    }
+
+    await dependencies.query(
+        `INSERT INTO reports (
+            user_id, mapset_id, report_type, description
+        ) VALUES (?, ?, ?, ?)`,
+        [report.userId, report.mapsetId, report.reportType, report.description]
+    );
+
+    if (!dependencies.webhookUrl) {
+        return;
+    }
+
+    const reportMessage = `
+**New Report**
+Type: ${report.reportType}
+Mapset: ${mapset.artist} - ${mapset.title}
+Mapset ID: ${report.mapsetId}
+Reported By: ${report.userId}
+
+Description:
+${escapeDiscordMentions(report.description)}
+
+Mapset Link: https://osu.ppy.sh/s/${report.mapsetId}
+`;
+
+    try {
+        const response = await (dependencies.fetchImpl ?? fetch)(dependencies.webhookUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                content: reportMessage,
+                allowed_mentions: { parse: [] },
+            }),
+        });
+
+        if (!response.ok) {
+            dependencies.logError?.(`Report webhook delivery failed with status ${response.status}`);
+        }
+    } catch {
+        dependencies.logError?.("Report webhook delivery failed");
+    }
+}

--- a/src/lib/report-service.ts
+++ b/src/lib/report-service.ts
@@ -13,7 +13,10 @@ interface ReportDependencies {
     webhookUrl?: string;
     fetchImpl?: FetchFunction;
     logError?: (message: string) => void;
+    webhookTimeoutMs?: number;
 }
+
+export const REPORT_WEBHOOK_TIMEOUT_MS = 5_000;
 
 export class ReportMapsetNotFoundError extends Error {
     constructor() {
@@ -59,21 +62,37 @@ Mapset Link: https://osu.ppy.sh/s/${report.mapsetId}
 `;
 
     try {
-        const response = await (dependencies.fetchImpl ?? fetch)(dependencies.webhookUrl, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-                content: reportMessage,
-                allowed_mentions: { parse: [] },
-            }),
-        });
+        const controller = new AbortController();
+        let timeout: ReturnType<typeof setTimeout> | undefined;
 
-        if (!response.ok) {
-            dependencies.logError?.(`Report webhook delivery failed with status ${response.status}`);
+        try {
+            const delivery = (dependencies.fetchImpl ?? fetch)(dependencies.webhookUrl, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    content: reportMessage,
+                    allowed_mentions: { parse: [] },
+                }),
+                signal: controller.signal,
+            });
+            const deadline = new Promise<never>((_, reject) => {
+                timeout = setTimeout(() => {
+                    controller.abort();
+                    reject(new Error("Report webhook delivery timed out"));
+                }, dependencies.webhookTimeoutMs ?? REPORT_WEBHOOK_TIMEOUT_MS);
+            });
+
+            const response = await Promise.race([delivery, deadline]);
+
+            if (!response.ok) {
+                dependencies.logError?.(`Report webhook delivery failed with status ${response.status}`);
+            }
+        } finally {
+            if (timeout) clearTimeout(timeout);
         }
-    } catch {
-        dependencies.logError?.("Report webhook delivery failed");
+    } catch (error) {
+        dependencies.logError?.(error instanceof Error && error.message === "Report webhook delivery timed out" ? error.message : "Report webhook delivery failed");
     }
 }

--- a/src/lib/report-validation.ts
+++ b/src/lib/report-validation.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const reportTypeSchema = z.enum(["incorrect_title", "inappropriate_content", "wrong_audio", "wrong_background", "other"]);
+export const reportStatusSchema = z.enum(["pending", "investigating", "resolved", "rejected"]);
+
+export const reportSchema = z.object({
+    mapsetId: z.number().int().positive(),
+    reportType: reportTypeSchema,
+    description: z.string().trim().min(10).max(1000),
+});
+
+export const reportStatusUpdateSchema = z.object({
+    reportId: z.number().int().positive(),
+    status: reportStatusSchema,
+});


### PR DESCRIPTION
Mapset reports are stored independently of the optional Discord notification, with bounded delivery and predictable validation failures.

- validates positive mapset/report IDs, report types, and admin status updates with Zod
- returns a controlled missing-mapset error instead of dereferencing an absent row
- inserts the database report before attempting optional webhook delivery
- skips Discord entirely when `DISCORD_WEBHOOK` is unset
- applies a five-second delivery deadline, sends an abort signal, and contains timeouts, network failures, and non-2xx responses
- logs only safe failure/status context without exposing the webhook URL
- preserves the skin-game report-button behavior already present on current `main`
- includes focused coverage for no webhook, Discord errors, timeout/abort behavior, missing mapsets, invalid report types, and invalid statuses

**Tests**

- `bun install --frozen-lockfile` — passed, no lockfile changes
- `bun run check` — passed
- `bun test` — passed (61 tests)
- `bun run build` — passed

**Visible behavior**

Skin rounds retain the existing hidden report control. Other report UI remains unchanged. Discord delivery failures no longer affect a report that was already recorded.

**Remaining limitations**

- Report storage schema, rate-limit policy, and admin report UI are unchanged.
- The deadline bounds how long report creation waits and requests cancellation through `AbortController`; it does not guarantee cancellation by an arbitrary custom transport after the action returns.