### PR TITLE
fix(seo): normalize metadata and localization

### DIFF
--- a/public/default-avatar.svg
+++ b/public/default-avatar.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">Default profile avatar</title>
+  <rect width="128" height="128" rx="64" fill="#23202f"/>
+  <circle cx="64" cy="48" r="24" fill="#8870ff" opacity=".72"/>
+  <path d="M20 118c4-27 21-42 44-42s40 15 44 42" fill="#8870ff" opacity=".5"/>
+</svg>

--- a/public/placeholder.svg
+++ b/public/placeholder.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675" role="img" aria-labelledby="title description">
+  <title id="title">Media unavailable</title>
+  <desc id="description">A neutral osu!guessr media placeholder</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#17151f"/>
+      <stop offset="1" stop-color="#23202f"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#background)"/>
+  <circle cx="600" cy="305" r="112" fill="none" stroke="#8870ff" stroke-width="18" opacity=".45"/>
+  <circle cx="600" cy="305" r="62" fill="#8870ff" opacity=".12"/>
+  <text x="600" y="500" fill="#d4cee8" font-family="system-ui, sans-serif" font-size="34" text-anchor="middle">Media unavailable</text>
+</svg>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow:
-
-Sitemap: https://osuguessr.com/sitemap.xml

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,7 +4,7 @@ import AboutClient from "./client";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "About | osu!guessr",
+    title: "About",
     description: "Learn more about osu!guessr, how to play, and game mechanics.",
 };
 

--- a/src/app/games/audio/page.tsx
+++ b/src/app/games/audio/page.tsx
@@ -9,7 +9,7 @@ import { Metadata } from "next";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "Audio Guessr | osu!guessr",
+    title: "Audio Guessr",
     description: "Challenge yourself by identifying songs from short audio clips.",
 };
 

--- a/src/app/games/background/page.tsx
+++ b/src/app/games/background/page.tsx
@@ -10,7 +10,7 @@ import { Metadata } from "next";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "Background Guessr | osu!guessr",
+    title: "Background Guessr",
     description: "Test your knowledge by guessing songs from their beatmap backgrounds.",
 };
 

--- a/src/app/games/skin/page.tsx
+++ b/src/app/games/skin/page.tsx
@@ -9,7 +9,7 @@ import { Metadata } from "next";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "Skin Guessr | osu!guessr",
+    title: "Skin Guessr",
     description: "Test your knowledge of osu! skins by identifying them from screenshots.",
 };
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: var(--public-sans), sans-serif;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,13 +11,20 @@ import { TranslationsProvider } from "@/context/translations-provider";
 import { auth } from "@/lib/auth";
 import { getLockInfo } from "@/lib/lockdown";
 import { OWNER_ID } from "@/lib";
+import { cookies } from "next/headers";
+import { env } from "@/lib/env";
+import { normalizePublicOrigin } from "@/lib/public-url";
+import { getTranslations, isLocale } from "@/lib/translations";
 
 const publicSans = Public_Sans({
     subsets: ["latin"],
     variable: "--public-sans",
 });
 
+const publicOrigin = normalizePublicOrigin(env.NEXT_PUBLIC_APP_URL);
+
 export const metadata: Metadata = {
+    metadataBase: new URL(publicOrigin),
     title: {
         default: "osu!guessr",
         template: "%s | osu!guessr",
@@ -34,9 +41,9 @@ export const metadata: Metadata = {
     openGraph: {
         title: "osu!guessr",
         description: "Guess osu! beatmaps from audio clips and screenshots. Free web game for osu! fans.",
-        url: "https://osuguessr.com",
+        url: publicOrigin,
         siteName: "osu!guessr",
-        images: [{ url: "https://osuguessr.com/main_bg.webp", width: 1200, height: 630 }],
+        images: [{ url: `${publicOrigin}/main_bg.webp`, width: 1200, height: 630 }],
         type: "website",
     },
 };
@@ -57,18 +64,21 @@ export default async function RootLayout({
 }: Readonly<{
     children: React.ReactNode;
 }>) {
-    const lock = await getLockInfo();
-    const session = await auth();
+    const [lock, session, cookieStore] = await Promise.all([getLockInfo(), auth(), cookies()]);
+    const localeCookie = cookieStore.get("locale")?.value;
+    const hasValidLocaleCookie = isLocale(localeCookie);
+    const initialLocale = hasValidLocaleCookie ? localeCookie : "en";
+    const t = getTranslations(initialLocale);
 
     if (lock && session?.user?.banchoId !== OWNER_ID) {
         return (
-            <html lang="en">
+            <html lang={initialLocale}>
                 <body className={`${publicSans.variable} antialiased`}>
                     <div className="flex items-center justify-center min-h-screen bg-background">
                         <div className="max-w-xl mx-auto p-8 bg-card rounded-lg border border-border">
-                            <h1 className="text-2xl font-bold mb-4">Website Locked</h1>
-                            <p className="mb-4">The site is temporarily locked until {new Date(lock.until).toLocaleString()}.</p>
-                            <p className="text-sm text-muted-foreground">Access is restricted. Only the owner can access the site while it&apos;s locked. Sorry for the inconvenience.</p>
+                            <h1 className="text-2xl font-bold mb-4">{t.lockdown.title}</h1>
+                            <p className="mb-4">{t.lockdown.until.replace("{date}", new Date(lock.until).toLocaleString(initialLocale))}</p>
+                            <p className="text-sm text-muted-foreground">{t.lockdown.description}</p>
                         </div>
                     </div>
                     <AnalyticsScripts />
@@ -78,7 +88,7 @@ export default async function RootLayout({
     }
 
     return (
-        <html lang="en">
+        <html lang={initialLocale}>
             <head>
                 {/* JSON-LD structured data for Site */}
                 <script
@@ -88,18 +98,13 @@ export default async function RootLayout({
                             "@context": "https://schema.org",
                             "@type": "WebSite",
                             name: "osu!guessr",
-                            url: "https://osuguessr.com",
-                            potentialAction: {
-                                "@type": "SearchAction",
-                                target: "https://osuguessr.com/search?q={search_term_string}",
-                                "query-input": "required name=search_term_string",
-                            },
+                            url: publicOrigin,
                         }),
                     }}
                 />
             </head>
             <body className={`${publicSans.variable} antialiased`}>
-                <TranslationsProvider>
+                <TranslationsProvider initialLocale={initialLocale} migrateStoredLocale={!hasValidLocaleCookie}>
                     <SessionWrapper>
                         <ThemeProvider attribute="class" defaultTheme="dark" disableTransitionOnChange>
                             <div className="flex min-h-screen flex-col bg-background text-foreground">

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -4,7 +4,7 @@ import LeaderboardClient from "./client";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "Leaderboard | osu!guessr",
+    title: "Leaderboard",
     description: "View the top players and their scores across different game modes.",
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,8 @@ async function HomeAnnouncements() {
 
 async function HomeChangelogs() {
     const changelogs = await readChangelogs();
+    if (changelogs.length === 0) return null;
+
     return (
         <section className="py-12">
             <ChangelogsSection changelogs={changelogs} />

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -4,7 +4,7 @@ import PrivacyPolicy from "./client";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "Privacy Policy | osu!guessr",
+    title: "Privacy Policy",
     description: "Learn about how we handle your data and privacy on osu!guessr.",
 };
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { env } from "@/lib/env";
+import { normalizePublicOrigin } from "@/lib/public-url";
+
+export default function robots(): MetadataRoute.Robots {
+    const origin = normalizePublicOrigin(env.NEXT_PUBLIC_APP_URL);
+
+    return {
+        rules: {
+            userAgent: "*",
+            allow: "/",
+        },
+        sitemap: `${origin}/sitemap.xml`,
+    };
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,7 +6,7 @@ import SettingsClient from "./SettingsClient";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "Settings | osu!guessr",
+    title: "Settings",
     description: "Manage your API keys and account settings",
 };
 

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,90 +1,12 @@
 import { NextResponse } from "next/server";
-import fs from "fs/promises";
-import path from "path";
 import { env } from "@/lib/env";
-
-const ORIGIN = env.NEXTAUTH_URL || "https://your-domain.example";
-
-const APP_DIR = path.join(process.cwd(), "src", "app");
-
-function isPageFile(name: string) {
-    return /^(page)\.(tsx|ts|jsx|js)$/.test(name);
-}
-
-async function collectPages(dir: string, routeBase = ""): Promise<Array<{ loc: string; lastmod?: string }>> {
-    let results: Array<{ loc: string; lastmod?: string }> = [];
-
-    const entries = await fs.readdir(dir, { withFileTypes: true });
-
-    const pageFile = entries.find((e) => e.isFile() && isPageFile(e.name));
-    if (pageFile) {
-        if (!routeBase.includes("[")) {
-            const filePath = path.join(dir, pageFile.name);
-            try {
-                const st = await fs.stat(filePath);
-                const loc = routeBase === "" ? "/" : routeBase;
-                results.push({ loc, lastmod: st.mtime.toISOString() });
-            } catch {}
-        }
-    }
-
-    for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-
-        if (entry.name === "api" || entry.name === "components" || entry.name === "_components" || entry.name === "admin") continue;
-
-        const segment = entry.name;
-        const nextBase = routeBase === "" ? `/${segment}` : `${routeBase}/${segment}`;
-        const childDir = path.join(dir, segment);
-        try {
-            const child = await collectPages(childDir, nextBase);
-            results = results.concat(child);
-        } catch {}
-    }
-
-    return results;
-}
-
-function formatUrl(loc: string, lastmod?: string, changefreq?: string, priority?: string) {
-    return `  <url>\n    <loc>${ORIGIN}${loc}</loc>\n${lastmod ? `    <lastmod>${new Date(lastmod).toISOString()}</lastmod>\n` : ""}${changefreq ? `    <changefreq>${changefreq}</changefreq>\n` : ""}${
-        priority ? `    <priority>${priority}</priority>\n` : ""
-    }  </url>`;
-}
+import { buildSitemapXml } from "@/lib/sitemap";
 
 export async function GET() {
-    const parts: string[] = [];
-
-    parts.push(formatUrl("/", undefined, "daily", "1.0"));
-    parts.push(formatUrl("/about", undefined, "monthly", "0.7"));
-    parts.push(formatUrl("/announcements", undefined, "weekly", "0.6"));
-    parts.push(formatUrl("/games", undefined, "weekly", "0.8"));
-    parts.push(formatUrl("/games/audio", undefined, "weekly", "0.6"));
-    parts.push(formatUrl("/games/background", undefined, "weekly", "0.6"));
-    parts.push(formatUrl("/games/skin", undefined, "weekly", "0.6"));
-    parts.push(formatUrl("/leaderboard", undefined, "daily", "0.7"));
-    parts.push(formatUrl("/privacy", undefined, "yearly", "0.3"));
-    parts.push(formatUrl("/settings", undefined, "monthly", "0.4"));
-    parts.push(formatUrl("/support", undefined, "monthly", "0.4"));
-    parts.push(formatUrl("/tos", undefined, "yearly", "0.2"));
-
-    try {
-        const pages = await collectPages(APP_DIR, "");
-        const seen = new Set<string>();
-        for (const p of pages) {
-            if (seen.has(p.loc)) continue;
-            seen.add(p.loc);
-            parts.push(formatUrl(p.loc, p.lastmod, "weekly", "0.6"));
-        }
-    } catch (err) {
-        console.error("Error collecting pages for sitemap:", err);
-    }
-
-    const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n${parts.join("\n")}\n</urlset>`;
-
-    return new NextResponse(xml, {
+    return new NextResponse(buildSitemapXml(env.NEXT_PUBLIC_APP_URL), {
         status: 200,
         headers: {
-            "Content-Type": "application/xml",
+            "Content-Type": "application/xml; charset=utf-8",
             "Cache-Control": "public, max-age=0, s-maxage=3600",
         },
     });

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -3,7 +3,7 @@ import { SupportPageContent } from "./client";
 export const dynamic = "force-dynamic";
 
 export const metadata = {
-    title: "Support osu!guessr",
+    title: "Support",
     description: "Support the development of osu!guessr and help keep the servers running",
 };
 

--- a/src/app/tos/page.tsx
+++ b/src/app/tos/page.tsx
@@ -4,7 +4,7 @@ import TosPolicy from "./client";
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-    title: "Terms of Service | osu!guessr",
+    title: "Terms of Service",
     description: "Read our terms of service and understand the rules and guidelines for using osu!guessr.",
 };
 

--- a/src/app/user/[banchoId]/page.tsx
+++ b/src/app/user/[banchoId]/page.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export async function generateMetadata(): Promise<Metadata> {
     return {
-        title: `User Profile | osu!guessr`,
+        title: "User Profile",
         description: `View player statistics and achievements on osu!guessr`,
     };
 }

--- a/src/components/Ads.tsx
+++ b/src/components/Ads.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Translations, useTranslations } from "@/hooks/use-translations";
+import type { Translations } from "@/lib/translations";
+import { useTranslationsContext } from "@/context/translations-provider";
 
 interface Promo {
     id: string;
@@ -43,7 +44,7 @@ const createPromos = (t: Translations): Array<Promo> => [
 ];
 
 export function AdSlider() {
-    const { t } = useTranslations();
+    const { t } = useTranslationsContext();
     const promos = createPromos(t);
     const [currentIndex, setCurrentIndex] = useState(0);
     const [sequence, setSequence] = useState(() => shuffle([...Array(promos.length).keys()]));

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -76,7 +76,7 @@ export default function Header() {
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                                 <Button variant="ghost" className="relative h-10 w-10 rounded-full p-0 active:!transform-none" aria-label={t.components.header.accessibility.profileMenu}>
-                                    <Image src={session.user?.image || "/default-avatar.png"} alt="Avatar" className="rounded-full" fill style={{ objectFit: "cover" }} />
+                                    <Image src={session.user?.image || "/default-avatar.svg"} alt="" className="rounded-full" fill style={{ objectFit: "cover" }} />
                                 </Button>
                             </DropdownMenuTrigger>
 
@@ -84,7 +84,7 @@ export default function Header() {
                                 <DropdownMenuItem className="cursor-pointer" asChild>
                                     <Link href={`/user/${session.user.banchoId}`} className="flex items-center">
                                         <div className="relative h-8 w-8 rounded-full mr-2">
-                                            <Image src={session.user?.image || "/default-avatar.png"} alt="Avatar" className="rounded-full" fill style={{ objectFit: "cover" }} />
+                                            <Image src={session.user?.image || "/default-avatar.svg"} alt="" className="rounded-full" fill style={{ objectFit: "cover" }} />
                                         </div>
                                         <div className="flex flex-col">
                                             <span className="font-medium">{session.user.name}</span>
@@ -94,7 +94,7 @@ export default function Header() {
                                 </DropdownMenuItem>
                                 {session.user.banchoId === OWNER_ID && (
                                     <DropdownMenuItem className="cursor-pointer" asChild>
-                                        <Link href="/admin">Admin</Link>
+                                        <Link href="/admin">{t.components.header.nav.admin}</Link>
                                     </DropdownMenuItem>
                                 )}
                                 <DropdownMenuItem className="cursor-pointer" asChild>

--- a/src/context/translations-provider.tsx
+++ b/src/context/translations-provider.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import { useTranslations } from "@/hooks/use-translations";
+import { Locale, useTranslations } from "@/hooks/use-translations";
 
 const TranslationsContext = createContext<ReturnType<typeof useTranslations> | null>(null);
 
-export function TranslationsProvider({ children }: { children: React.ReactNode }) {
-    const translations = useTranslations();
+export function TranslationsProvider({ children, initialLocale, migrateStoredLocale = false }: { children: React.ReactNode; initialLocale: Locale; migrateStoredLocale?: boolean }) {
+    const translations = useTranslations(initialLocale, migrateStoredLocale);
 
     return <TranslationsContext.Provider value={translations}>{children}</TranslationsContext.Provider>;
 }

--- a/src/hooks/use-translations.ts
+++ b/src/hooks/use-translations.ts
@@ -1,80 +1,38 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import en from "@/messages/en.json";
-import tr from "@/messages/tr.json";
-import cs from "@/messages/cs.json";
-import es from "@/messages/es.json";
-import pl from "@/messages/pl.json";
-import ru from "@/messages/ru.json";
+import { getTranslations, isLocale, Locale } from "@/lib/translations";
 
-export const languages = {
-    en: "English",
-    tr: "Türkçe",
-    cs: "Čeština",
-    es: "Español",
-    pl: "Polski",
-    ru: "Русский",
-} as const;
+export { languages } from "@/lib/translations";
+export type { Locale, Translations } from "@/lib/translations";
 
-const messages = { en, tr, cs, es, pl, ru } as const;
-export type Locale = keyof typeof messages;
-export type Translations = typeof en;
-
-export function useTranslations() {
-    const [locale, setLocale] = useState<Locale>("en");
+export function useTranslations(initialLocale: Locale = "en", migrateStoredLocale = false) {
+    const [locale, setLocale] = useState<Locale>(initialLocale);
 
     useEffect(() => {
-        const stored = localStorage.getItem("locale") as Locale;
-        if (stored && stored in messages) {
-            setLocale(stored);
+        const stored = localStorage.getItem("locale");
+        if (migrateStoredLocale && isLocale(stored)) {
+            document.cookie = `locale=${stored}; path=/; max-age=31536000; samesite=lax`;
+            document.documentElement.lang = stored;
+
+            if (stored !== locale) {
+                setLocale(stored);
+                return;
+            }
         }
-    }, []);
+
+        document.documentElement.lang = locale;
+    }, [locale, migrateStoredLocale]);
 
     const setLanguage = (newLocale: Locale) => {
         localStorage.setItem("locale", newLocale);
+        document.cookie = `locale=${newLocale}; path=/; max-age=31536000; samesite=lax`;
+        document.documentElement.lang = newLocale;
         setLocale(newLocale);
-        window.location.reload();
-    };
-
-    const processMessage = (message: string) => {
-        return message
-            .replace(/\{osu_guessr\}/g, "osu!guessr")
-            .replace(/\{osu_base\}/g, "osu!")
-            .replace(/\{artist_name\}/g, "Triantafyllia");
-    };
-
-    /* eslint-disable  @typescript-eslint/no-explicit-any */
-    const processTranslations = (obj: any, fallback: any = messages.en): any => {
-        return new Proxy(
-            {},
-            {
-                get(_, prop) {
-                    const value = obj[prop] ?? fallback[prop];
-
-                    if (typeof value === "string") {
-                        return processMessage(value);
-                    }
-                    if (typeof value === "object" && value !== null) {
-                        return processTranslations(obj[prop] || {}, fallback[prop]);
-                    }
-                    return value;
-                },
-                ownKeys() {
-                    return [...new Set([...Object.keys(obj), ...Object.keys(fallback)])];
-                },
-                getOwnPropertyDescriptor() {
-                    return {
-                        enumerable: true,
-                        configurable: true,
-                    };
-                },
-            }
-        );
     };
 
     return {
-        t: processTranslations(messages[locale]) as Translations,
+        t: getTranslations(locale),
         locale,
         setLanguage,
     };

--- a/src/lib/public-url.ts
+++ b/src/lib/public-url.ts
@@ -1,0 +1,9 @@
+const DEFAULT_PUBLIC_ORIGIN = "http://localhost:3000";
+
+export function normalizePublicOrigin(value?: string): string {
+    try {
+        return new URL(value || DEFAULT_PUBLIC_ORIGIN).origin;
+    } catch {
+        return DEFAULT_PUBLIC_ORIGIN;
+    }
+}

--- a/src/lib/sitemap.test.ts
+++ b/src/lib/sitemap.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { buildSitemapXml, PUBLIC_SITEMAP_ROUTES } from "./sitemap";
+
+describe("sitemap generation", () => {
+    test("contains each public route exactly once and excludes private or nonexistent routes", () => {
+        const paths = PUBLIC_SITEMAP_ROUTES.map((route) => route.path);
+        expect(new Set(paths).size).toBe(paths.length);
+        expect(paths).not.toContain("/games");
+        expect(paths).not.toContain("/settings");
+    });
+
+    test("uses the configured public origin without duplicate routes", () => {
+        const xml = buildSitemapXml("https://example.com/app/");
+        expect(xml).toContain("<loc>https://example.com/</loc>");
+        expect(xml.match(/<loc>https:\/\/example\.com\/about<\/loc>/g)).toHaveLength(1);
+    });
+
+    test("escapes XML values", () => {
+        const xml = buildSitemapXml("https://example.com", [{ path: "/search?one=1&two=2", changeFrequency: "monthly", priority: 0.5 }]);
+        expect(xml).toContain("one=1&amp;two=2");
+    });
+});

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -1,0 +1,35 @@
+import { normalizePublicOrigin } from "./public-url";
+
+export interface SitemapRoute {
+    path: string;
+    changeFrequency: "daily" | "weekly" | "monthly" | "yearly";
+    priority: number;
+}
+
+export const PUBLIC_SITEMAP_ROUTES: SitemapRoute[] = [
+    { path: "/", changeFrequency: "daily", priority: 1 },
+    { path: "/about", changeFrequency: "monthly", priority: 0.7 },
+    { path: "/announcements", changeFrequency: "weekly", priority: 0.6 },
+    { path: "/games/audio", changeFrequency: "weekly", priority: 0.6 },
+    { path: "/games/background", changeFrequency: "weekly", priority: 0.8 },
+    { path: "/games/skin", changeFrequency: "weekly", priority: 0.6 },
+    { path: "/leaderboard", changeFrequency: "daily", priority: 0.7 },
+    { path: "/privacy", changeFrequency: "yearly", priority: 0.3 },
+    { path: "/support", changeFrequency: "monthly", priority: 0.4 },
+    { path: "/tos", changeFrequency: "yearly", priority: 0.2 },
+];
+
+export function escapeSitemapXml(value: string): string {
+    return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+export function buildSitemapXml(origin: string, routes: SitemapRoute[] = PUBLIC_SITEMAP_ROUTES): string {
+    const publicOrigin = normalizePublicOrigin(origin);
+    const uniqueRoutes = [...new Map(routes.map((route) => [route.path, route])).values()];
+    const entries = uniqueRoutes.map((route) => {
+        const location = escapeSitemapXml(new URL(route.path, `${publicOrigin}/`).toString());
+        return `  <url>\n    <loc>${location}</loc>\n    <changefreq>${route.changeFrequency}</changefreq>\n    <priority>${route.priority.toFixed(1)}</priority>\n  </url>`;
+    });
+
+    return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries.join("\n")}\n</urlset>`;
+}

--- a/src/lib/translations.test.ts
+++ b/src/lib/translations.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { isLocale, languages } from "./translations";
+
+describe("isLocale", () => {
+    test("accepts every registered locale", () => {
+        for (const locale of Object.keys(languages)) {
+            expect(isLocale(locale)).toBe(true);
+        }
+    });
+
+    test("rejects inherited object property names", () => {
+        for (const inheritedName of ["constructor", "toString", "__proto__"]) {
+            expect(isLocale(inheritedName)).toBe(false);
+        }
+    });
+});

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -1,0 +1,63 @@
+import en from "@/messages/en.json";
+import tr from "@/messages/tr.json";
+import cs from "@/messages/cs.json";
+import es from "@/messages/es.json";
+import pl from "@/messages/pl.json";
+import ru from "@/messages/ru.json";
+
+export const languages = {
+    en: "English",
+    tr: "Türkçe",
+    cs: "Čeština",
+    es: "Español",
+    pl: "Polski",
+    ru: "Русский",
+} as const;
+
+const messages = { en, tr, cs, es, pl, ru } as const;
+export type Locale = keyof typeof messages;
+export type Translations = typeof en;
+
+export function isLocale(value: unknown): value is Locale {
+    return typeof value === "string" && Object.hasOwn(messages, value);
+}
+
+function processMessage(message: string) {
+    return message
+        .replace(/\{osu_guessr\}/g, "osu!guessr")
+        .replace(/\{osu_base\}/g, "osu!")
+        .replace(/\{artist_name\}/g, "Triantafyllia");
+}
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+function processTranslations(obj: any, fallback: any = messages.en): any {
+    return new Proxy(
+        {},
+        {
+            get(_, prop) {
+                const value = obj[prop] ?? fallback[prop];
+
+                if (typeof value === "string") {
+                    return processMessage(value);
+                }
+                if (typeof value === "object" && value !== null) {
+                    return processTranslations(obj[prop] || {}, fallback[prop]);
+                }
+                return value;
+            },
+            ownKeys() {
+                return [...new Set([...Object.keys(obj), ...Object.keys(fallback)])];
+            },
+            getOwnPropertyDescriptor() {
+                return {
+                    enumerable: true,
+                    configurable: true,
+                };
+            },
+        }
+    );
+}
+
+export function getTranslations(locale: Locale): Translations {
+    return processTranslations(messages[locale]) as Translations;
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -178,6 +178,11 @@
             "funFact": "Did you know? I didn't either!"
         }
     },
+    "lockdown": {
+        "title": "Website Locked",
+        "until": "The site is temporarily locked until {date}.",
+        "description": "Access is restricted. Only the owner can access the site while it is locked. Sorry for the inconvenience."
+    },
     "about": {
         "title": "About {osu_guessr}",
         "whatIs": {
@@ -680,7 +685,8 @@
                 "settings": "Settings",
                 "signIn": "Sign In",
                 "signOut": "Sign out",
-                "viewProfile": "View Profile"
+                "viewProfile": "View Profile",
+                "admin": "Admin"
             }
         },
         "footer": {


### PR DESCRIPTION
Metadata, public discovery files, fallback assets, typography, and the existing localization provider now agree on the application’s real routes and configured public origin.

- makes child titles page-specific so the root title template appends `osu!guessr` once
- builds metadata, Open Graph, structured data, robots, and sitemap URLs from `NEXT_PUBLIC_APP_URL`
- uses one explicit deduplicated public-route list, excluding `/games` and `/settings`, and escapes sitemap XML
- removes the structured-data search action for the nonexistent `/search` route
- adds valid local media-placeholder and default-avatar SVG assets and applies Public Sans globally
- omits the homepage changelog section when no entries exist
- validates locale values with an own-property check, rejecting inherited names such as `constructor`, `toString`, and `__proto__`
- initializes locale and `<html lang>` from a validated cookie, migrates legacy localStorage without a transient wrong language, and updates reactively without a reload
- preserves the accessible header/menu/language controls and closed-menu behavior merged through PR #36

**Tests**

- `bun install --frozen-lockfile` — passed, no lockfile changes
- `bun run check` — passed
- `bun test` — passed (60 tests)
- `bun run build` — passed

**Conflict resolution**

Header and English-message conflicts were resolved by retaining PR #36’s accessibility names, mobile navigation behavior, and 320px-safe layout while applying the corrected fallback asset and localization additions.

**Visible changes**

Missing avatars/media use intentional local fallback artwork, Public Sans is global, empty changelogs leave no blank section, and language changes update in place with a correct document language.

**Remaining limitation**

Users with only the legacy localStorage preference and no valid locale cookie perform a one-time client migration; subsequent renders are cookie-initialized.