### PR TITLE
docs: update project setup and API reference

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -59,7 +59,7 @@ NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=""
 # -----------------------------------------------------------------------------
 
 # Optional Discord webhook URL used only for report notifications.
-# Storing reports without this value depends on open PR #39 until it is merged.
+# Reports are still stored when this value is empty.
 # Create one from Discord channel settings under Integrations > Webhooks.
 DISCORD_WEBHOOK=""
 

--- a/.env.template
+++ b/.env.template
@@ -59,7 +59,7 @@ NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=""
 # -----------------------------------------------------------------------------
 
 # Optional Discord webhook URL used only for report notifications.
-# Reports are still stored when this value is empty.
+# Storing reports without this value depends on open PR #39 until it is merged.
 # Create one from Discord channel settings under Integrations > Webhooks.
 DISCORD_WEBHOOK=""
 

--- a/.env.template
+++ b/.env.template
@@ -58,7 +58,8 @@ NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=""
 # Reports
 # -----------------------------------------------------------------------------
 
-# Optional Discord webhook URL used for user reports.
+# Optional Discord webhook URL used only for report notifications.
+# Reports are still stored when this value is empty.
 # Create one from Discord channel settings under Integrations > Webhooks.
 DISCORD_WEBHOOK=""
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ osu!guessr is a browser guessing game for identifying osu! beatmaps from backgro
 
     Register an osu! OAuth application at [osu! account settings](https://osu.ppy.sh/home/account/edit#oauth). Generate independent secrets for `AUTH_SECRET` and `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`; do not reuse the placeholders in production.
 
-    `DISCORD_WEBHOOK` is optional for the application. Storing reports without sending a Discord notification depends on open PR [#39](https://github.com/hanami-osu/osu-guessr/pull/39); configure a webhook until that change is merged if report submission must work on the current `main` branch.
+    `DISCORD_WEBHOOK` is optional. Reports are stored even when it is unset; the variable only enables Discord notifications.
 
 4. Prepare a database.
 

--- a/README.md
+++ b/README.md
@@ -1,124 +1,117 @@
 # osu!guessr
 
-Test your knowledge of osu! beatmaps in this engaging guessing game. Challenge yourself to identify songs from their background images, music snippets, or skin elements.
-
-## How to Play
-
-1. Sign in with your osu! account
-2. Choose a game mode (currently Background Guessr)
-3. Try to guess the song title from the displayed information
-4. Earn points based on:
-    - Correct answers (+100 base points)
-    - Quick responses (time bonus)
-    - Consecutive correct answers (streak bonus)
-
-## Documentation
-
--   [Sequence Diagram](./docs/game-flow.md) - Visual representation of the game flow
--   [API Documentation](./docs/API.md) - API endpoints and usage
-
-## Translations
-
-We welcome translations to make osu!guessr accessible to more players! Check our [Translation Guide](./docs/Translating.md) to help translate the game into your language.
-
-Currently supported languages:
-
--   English
--   Turkish
-
-Want to add your language? Follow the guide and submit a PR!
+osu!guessr is a browser guessing game for identifying osu! beatmaps from backgrounds, audio clips, and skin screenshots.
 
 ## Features
 
--   **Background Guessr**: Identify songs from their beatmap backgrounds
--   **Audio Guessr**: Test your music recognition skills
--   **Skin Guessr**: Challenge yourself to recognize popular osu! skins
+- **Background Guessr**: identify songs from beatmap backgrounds.
+- **Audio Guessr**: identify songs from audio clips.
+- **Skin Guessr**: identify community skins from screenshots.
+- Classic and death variants, leaderboards, profiles, achievements, reports, and API keys.
+- English, Turkish, Czech, Spanish, Polish, and Russian interfaces.
 
-## Getting Started
+## Documentation
 
-1. **Prerequisites**
+- [API documentation](./docs/API.md)
+- [Translation guide](./docs/TRANSLATING.md)
 
-    - Node.js 18+
-    - MariaDB/MySQL database
-    - osu! API key
+## Requirements
 
-2. **Installation**
+- [Bun](https://bun.sh/) 1.3 or newer
+- MariaDB or MySQL
+- Redis
+- An osu! OAuth application and legacy API key
+
+## Local development
+
+1. Clone the canonical repository and install dependencies:
 
     ```bash
-    git clone https://github.com/yorunoken/osu-guessr.git
+    git clone https://github.com/hanami-osu/osu-guessr.git
     cd osu-guessr
     bun install
     ```
 
-3. **Environment Setup**
+2. Create the local environment file:
 
     ```bash
     cp .env.template .env
     ```
 
-    Fill in your environment variables:
+3. Configure at least the following values in `.env`:
 
     ```env
-    # Server Configuration
     PORT=3000
-    SERVER_PORT=4000
 
-    # osu! API Configuration
-    OSU_CLIENT_ID=your_client_id
-    OSU_CLIENT_SECRET=your_client_secret
-    OSU_API_KEY=your_api_key
+    OSU_CLIENT_ID="your_client_id"
+    OSU_CLIENT_SECRET="your_client_secret"
+    OSU_API_KEY="your_api_key"
 
-    # NextAuth Configuration
-    NEXTAUTH_URL=https://your-domain.com
-    AUTH_SECRET=your_secret_key
+    NEXTAUTH_URL="http://localhost:3000"
+    NEXT_PUBLIC_APP_URL="http://localhost:3000"
+    AUTH_SECRET="a_random_secret"
+    NEXT_SERVER_ACTIONS_ENCRYPTION_KEY="a_stable_random_key"
 
-    # Database
-    DB_HOST=mariadb_shared
-    # Or, for custom credentials/name:
-    # DATABASE_URL=mysql://user:password@host:3306/osu_guessr
+    DATABASE_URL="mysql://user:password@127.0.0.1:3306/osu_guessr"
+    REDIS_URL="redis://127.0.0.1:6379"
     ```
 
-    You'll need to:
+    Register an osu! OAuth application at [osu! account settings](https://osu.ppy.sh/home/account/edit#oauth). Generate independent secrets for `AUTH_SECRET` and `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`; do not reuse the placeholders in production.
 
-    - Register an osu! OAuth application at https://osu.ppy.sh/home/account/edit#oauth
-    - Get an osu! API key from https://osu.ppy.sh/p/api
-    - Set your `NEXTAUTH_URL` to your domain (use `http://localhost:3000` for local development)
-    - Generate a random string for `AUTH_SECRET`
+    `DISCORD_WEBHOOK` is optional. When it is empty, reports are stored without sending a Discord notification.
 
-4. **Database Setup**
+4. Prepare a database.
+
+    > [!CAUTION]
+    > `init.sql` is only for a brand-new, disposable development database. It disables foreign-key checks and drops existing application tables before recreating them. Never run it against an existing, shared, staging, or production database. A migration-based installation path is tracked separately and is not replaced by this command.
+
+    For a fresh disposable development database only:
 
     ```bash
     mysql -u your_database_user -p osu_guessr < init.sql
     bun run prisma:generate
     ```
 
-    MariaDB remains the database engine. Prisma is used as the application data-access layer, and `bun run db:introspect` can refresh `prisma/schema.prisma` from an existing database when needed.
+    Existing environments must use their established schema-management process. `bun run db:introspect` reads an existing database into `prisma/schema.prisma`; it is not a migration command.
 
-5. **Development**
+5. Start the development server:
+
     ```bash
     bun run dev
     ```
 
-## Built With
+## Validation
 
--   [Next.js 15](https://nextjs.org/) - React framework
--   [NextAuth.js](https://next-auth.js.org/) - Authentication
--   [Tailwind CSS](https://tailwindcss.com/) - Styling
--   [Prisma](https://www.prisma.io/) - Database access
--   [MariaDB/MySQL](https://mariadb.org/) - Database
--   [TypeScript](https://www.typescriptlang.org/) - Language
+Run the same quality gates used for changes:
+
+```bash
+bun run check
+bun test
+bun run build
+```
+
+## Production notes
+
+- Use production-specific secrets and HTTPS URLs.
+- Keep `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` stable across replicas and deployments.
+- Back MariaDB, Redis, and imported media with appropriate persistent storage.
+- Do not use `init.sql` to update an existing deployment.
+
+## Built with
+
+- [Next.js 16](https://nextjs.org/)
+- [React 19](https://react.dev/)
+- [NextAuth.js](https://authjs.dev/)
+- [Tailwind CSS](https://tailwindcss.com/)
+- [Prisma](https://www.prisma.io/)
+- [MariaDB](https://mariadb.org/)
+- [TypeScript](https://www.typescriptlang.org/)
 
 ## License
 
-This project is licensed under the GNU Affero General Public License v3.0 (AGPLv3) - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
--   Thanks to the osu! team for providing the API
--   All beatmap creators for their amazing work
--   The osu! community for their support
+This project is licensed under the GNU Affero General Public License v3.0. See [LICENSE](LICENSE).
 
 ## Contact
 
--   GitHub Issues: [Create an issue](https://github.com/yorunoken/osu-guessr/issues)
--   Twitter: [@\_yorunoken](https://twitter.com/_yorunoken)
+- [GitHub issues](https://github.com/hanami-osu/osu-guessr/issues)
+- [@_yorunoken on Twitter](https://twitter.com/_yorunoken)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ osu!guessr is a browser guessing game for identifying osu! beatmaps from backgro
 
     Register an osu! OAuth application at [osu! account settings](https://osu.ppy.sh/home/account/edit#oauth). Generate independent secrets for `AUTH_SECRET` and `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY`; do not reuse the placeholders in production.
 
-    `DISCORD_WEBHOOK` is optional. When it is empty, reports are stored without sending a Discord notification.
+    `DISCORD_WEBHOOK` is optional for the application. Storing reports without sending a Discord notification depends on open PR [#39](https://github.com/hanami-osu/osu-guessr/pull/39); configure a webhook until that change is merged if report submission must work on the current `main` branch.
 
 4. Prepare a database.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,225 +1,212 @@
-# osu!guessr API Documentation
+# osu!guessr API
 
-This documentation describes the available endpoints for the osu!guessr API.
+The public API returns JSON and requires an API key in the `X-API-Key` header. Signed-in users can create API keys from the settings page.
 
-All requests require an API key provided in the `X-API-Key` header. You can obtain an API key from your account settings.
+```http
+X-API-Key: your_api_key
+```
 
-------------------------------------------------------------------------------------------
+User IDs are positive osu! user IDs. Unless noted otherwise, timestamps are ISO 8601 strings and database aggregate values are serialized as JSON numbers.
 
 ## Endpoints
 
-### Get User
+### Get a user
+
 ```http
 GET /api/users/{userId}
 ```
 
-Retrieves information about a specific user.
-
-**Response Data:**
 ```typescript
 {
-    success: true,
+    success: true;
     data: {
         bancho_id: number;
         username: string;
         avatar_url: string;
+        created_at: string;
         badges: Array<{
             name: string;
             color: string;
-            assigned_at: Date;
+            assigned_at: string;
         }>;
-        created_at: Date;
-        achievements?: Array<{
+        achievements: Array<{
             user_id: number;
             game_mode: "background" | "audio" | "skin";
             variant: "classic" | "death";
-            total_score: bigint;
+            total_score: number;
             games_played: number;
             highest_streak: number;
             highest_score: number;
-            last_played: Date;
+            last_played: string;
         }>;
-        ranks?: {
+        ranks: {
             globalRank?: {
                 classic?: number;
                 death?: number;
             };
             modeRanks: {
-                background: {
-                    classic?: number;
-                    death?: number;
-                };
-                audio: {
-                    classic?: number;
-                    death?: number;
-                };
-                skin: {
-                    classic?: number;
-                    death?: number;
-                };
+                background: { classic?: number; death?: number };
+                audio: { classic?: number; death?: number };
+                skin: { classic?: number; death?: number };
             };
         };
-    }
+    };
 }
 ```
 
-### Get User's Games
+Returns `404` when the user does not exist. Rank fields can be absent when the user is unranked.
+
+### Get a user's games
+
 ```http
 GET /api/users/{userId}/games
 ```
 
-Retrieves a list of games played by a specific user.
+Query parameters:
 
-Query Parameters:
-- `mode` (optional): Filter by game mode ("background" | "audio" | "skin")
-- `limit` (optional): Number of results to return (default: 20, max: 100)
-- `offset` (optional): Number of results to skip (default: 0)
+- `mode` (optional): `background`, `audio`, or `skin`.
+- `variant` (optional): `classic` or `death`; defaults to `classic`.
+- `limit` (optional): integer from 1 to 100; defaults to 20.
+- `offset` (optional): non-negative integer; defaults to 0.
 
-**Response Data:**
 ```typescript
 {
-    success: true,
+    success: true;
     data: Array<{
         user_id: number;
         game_mode: "background" | "audio" | "skin";
         points: number;
         streak: number;
         variant: "classic" | "death";
-        ended_at: Date;
-    }>,
+        ended_at: string;
+    }>;
     meta: {
         total: number;
         offset: number;
-        limit: number
-    }
+        limit: number;
+    };
 }
 ```
 
-### Get User's Stats
+### Get a user's statistics
+
 ```http
 GET /api/users/{userId}/stats
 ```
 
-Retrieves statistics for a specific user.
+Query parameters:
 
-Query Parameters:
-- `mode` (optional): Filter by game mode ("background" | "audio" | "skin")
+- `mode` (optional): `background`, `audio`, or `skin`.
 
-**Response Data:**
 ```typescript
 {
-    success: true,
-    data: {
+    success: true;
+    data: Array<{
         user_id: number;
         game_mode: "background" | "audio" | "skin";
-        variant: "classic" | "death";
-        total_score: bigint;
+        total_score: number;
         games_played: number;
         highest_streak: number;
         highest_score: number;
-        last_played: Date;
-    }
+        last_played: string;
+    }>;
 }
 ```
 
-### Search Users
+This route currently returns one array entry per stored user-achievement row. The current query does not include a `variant` field.
+
+### Search users
+
 ```http
-GET /api/users/search
+GET /api/users/search?query=player
 ```
 
-Search for users by username.
+Query parameters:
 
-Query Parameters:
-- `query`: Search term (min length: 2, max length: 250)
-- `limit` (optional): Number of results to return (default: 20, max: 100)
+- `query` (required): 2 to 250 characters.
+- `limit` (optional): integer from 1 to 100; defaults to 20.
 
-**Response Data:**
 ```typescript
 {
-    success: true,
+    success: true;
     data: Array<{
         bancho_id: number;
         username: string;
         avatar_url: string;
-        badges: Array<{
-            name: string;
-            color: string;
-            assigned_at: Date;
-        }>;
-        created_at: Date;
-    }>
+        created_at: string;
+    }>;
 }
 ```
 
-### Get Leaderboard
+### Get the leaderboard
+
 ```http
 GET /api/games/leaderboard
 ```
 
-Retrieves the global leaderboard.
+Query parameters:
 
-Query Parameters:
-- `mode`: Game mode ("background" | "audio" | "skin")
-- `variant`: Game variant ("classic" | "death")
-- `limit` (optional): Number of results to return (default: 100, max: 100)
+- `mode` (optional): `background`, `audio`, or `skin`; defaults to `background`.
+- `variant` (optional): `classic` or `death`; defaults to `classic`.
+- `limit` (optional): integer from 1 to 100; defaults to 100.
 
-**Response Data:**
 ```typescript
 {
-    success: true,
+    success: true;
     data: Array<{
         bancho_id: number;
         username: string;
         avatar_url: string;
-        total_score: bigint;
+        created_at: string;
+        total_score: number;
         games_played: number;
         highest_streak: number;
         highest_score: number;
-        variant: "classic" | "death";
+        earliest_ended_at: string;
         badges: Array<{
             name: string;
             color: string;
-            assigned_at: Date;
         }>;
-    }>
+    }>;
 }
 ```
 
-### Get Global Stats
+The selected variant determines the calculation but is not currently repeated as a property on each leaderboard row.
+
+### Get global statistics
+
 ```http
 GET /api/stats
 ```
 
-Retrieves global game statistics.
+Query parameters:
 
-Query Parameters:
-- `variant`: Game variant ("classic" | "death")
+- `variant` (optional): `classic` or `death`; defaults to `classic`.
 
-**Response Data:**
 ```typescript
 {
-    success: true,
+    success: true;
     data: {
         highest_points: number;
         total_games: number;
         total_users: number;
-    }
+    };
 }
 ```
 
-## Response Format
+## Response format
 
-All API responses follow this general structure:
+Successful responses use:
 
-**Success Response:**
 ```json
 {
     "success": true,
-    "data": {...}
+    "data": {}
 }
 ```
 
-**Error Response:**
+Errors use:
+
 ```json
 {
     "success": false,
@@ -227,21 +214,21 @@ All API responses follow this general structure:
 }
 ```
 
-Common HTTP status codes:
-- 200: Success
-- 400: Bad Request
-- 403: Invalid API key
-- 404: Resource not found
-- 500: Internal Server Error
+HTTP statuses:
 
-------------------------------------------------------------------------------------------
+- `200`: success.
+- `400`: malformed path or query parameters.
+- `401`: API key missing.
+- `403`: API key invalid.
+- `404`: requested resource not found.
+- `429`: API key rate limit exceeded.
+- `500`: unexpected internal failure.
+- `503`: API-key validation dependency unavailable.
 
-## Rate Limits
+## Rate limits
 
-No rate limits currently. Don't fuck it with it.
+Each API key is limited to 120 requests per 60-second fixed window. Requests above that limit return `429`. Rate limiting requires Redis; a Redis or database failure during API-key validation returns an internal-service error rather than an invalid-key response.
 
 ## Support
 
-If you need help or have questions about the API, you can:
-- Open an issue on our [GitHub repository](https://github.com/yorunoken/osu-guessr)
-- Contact us on Discord: @yorunoken
+Open questions and bug reports in the [canonical GitHub repository](https://github.com/hanami-osu/osu-guessr/issues).

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -12,7 +12,9 @@ osu!guessr uses JSON-based translation files located in `src/messages/`. Each la
    - Use the standard two-letter language code (e.g., `fr.json` for French)
    - Copy the content from `en.json` as a starting point
 
-3. Make sure to maintain the same structure as the English file, only changing the text values
+2. Import the file and register its code and display name in the translation registry used by `src/hooks/use-translations.ts`.
+
+3. Maintain the same structure as the English file, changing only text values.
 
 ## Translation Guidelines
 
@@ -55,6 +57,10 @@ osu!guessr uses JSON-based translation files located in `src/messages/`. Each la
 Currently supported languages:
 - English (en)
 - Turkish (tr)
+- Czech (cs)
+- Spanish (es)
+- Polish (pl)
+- Russian (ru)
 
 ## Need Help?
 

--- a/src/app/about/client.tsx
+++ b/src/app/about/client.tsx
@@ -133,7 +133,7 @@ export default function AboutClient() {
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.documentation.api.title}</h3>
                             <p className="text-foreground/80 mb-4">{t.about.documentation.api.description}</p>
                             <a
-                                href="https://github.com/yorunoken/osu-guessr/blob/main/docs/API.md"
+                                href="https://github.com/hanami-osu/osu-guessr/blob/main/docs/API.md"
                                 className="text-primary hover:underline inline-flex items-center gap-2"
                                 target="_blank"
                                 rel="noopener noreferrer"
@@ -145,7 +145,7 @@ export default function AboutClient() {
                             <h3 className="text-xl font-medium mb-2 text-primary">{t.about.documentation.technical.title}</h3>
                             <p className="text-foreground/80 mb-4">{t.about.documentation.technical.description}</p>
                             <a
-                                href="https://github.com/yorunoken/osu-guessr/blob/main/docs/game-flow.md"
+                                href="https://github.com/hanami-osu/osu-guessr#readme"
                                 className="text-primary hover:underline inline-flex items-center gap-2"
                                 target="_blank"
                                 rel="noopener noreferrer"
@@ -214,7 +214,7 @@ export default function AboutClient() {
                             <div className="space-y-2">
                                 <p className="text-foreground/80">
                                     • GitHub:{" "}
-                                    <a href="https://github.com/yorunoken/osu-guessr" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
+                                    <a href="https://github.com/hanami-osu/osu-guessr" className="text-primary hover:underline" target="_blank" rel="noopener noreferrer">
                                         osu-guessr
                                     </a>
                                 </p>
@@ -236,7 +236,7 @@ export default function AboutClient() {
                                 <p className="text-foreground/80">{t.about.contact.contribute.items.bugs}</p>
                                 <p className="text-foreground/80">{t.about.contact.contribute.items.code}</p>
                                 <p className="text-foreground/80">{t.about.contact.contribute.items.docs}</p>
-                                <a href="https://github.com/yorunoken/osu-guessr" className="text-primary hover:underline inline-flex items-center gap-2 mt-2" target="_blank" rel="noopener noreferrer">
+                                <a href="https://github.com/hanami-osu/osu-guessr" className="text-primary hover:underline inline-flex items-center gap-2 mt-2" target="_blank" rel="noopener noreferrer">
                                     {t.common.viewMore} →
                                 </a>
                             </div>

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export async function GET() {
-    return redirect("https://github.com/yorunoken/osu-guessr/blob/main/docs/API.md");
+    return redirect("https://github.com/hanami-osu/osu-guessr/blob/main/docs/API.md");
 }

--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export async function GET() {
-    return redirect("https://github.com/yorunoken/osu-guessr/blob/main/docs/API.md");
+    return redirect("https://github.com/hanami-osu/osu-guessr/blob/main/docs/API.md");
 }

--- a/src/app/components/Changelogs.tsx
+++ b/src/app/components/Changelogs.tsx
@@ -32,7 +32,7 @@ export function ChangelogsSection({ changelogs }: ChangelogsProps) {
                                         <div className="space-x-2 text-sm">
                                             {change.commit && (
                                                 <a
-                                                    href={`https://github.com/yorunoken/osu-guessr/commit/${change.commit}`}
+                                                    href={`https://github.com/hanami-osu/osu-guessr/commit/${change.commit}`}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                     className="text-primary hover:underline inline-block"
@@ -42,7 +42,7 @@ export function ChangelogsSection({ changelogs }: ChangelogsProps) {
                                             )}
                                             {change.pr && (
                                                 <a
-                                                    href={`https://github.com/yorunoken/osu-guessr/pull/${change.pr}`}
+                                                    href={`https://github.com/hanami-osu/osu-guessr/pull/${change.pr}`}
                                                     target="_blank"
                                                     rel="noopener noreferrer"
                                                     className="text-primary hover:underline inline-block"

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -26,8 +26,8 @@ export default function NotFound() {
                     <div className="mt-8 pt-6 border-t border-border/50">
                         <p className="text-sm text-foreground/50">
                             {t.errors["404"].reportIssue}{" "}
-                            <Link href="https://github.com/yorunoken/osu-guessr/issues" className="text-primary hover:underline">
-                                https://github.com/yorunoken/osu-guessr/issues
+                            <Link href="https://github.com/hanami-osu/osu-guessr/issues" className="text-primary hover:underline">
+                                https://github.com/hanami-osu/osu-guessr/issues
                             </Link>
                             .
                         </p>

--- a/src/app/privacy/client.tsx
+++ b/src/app/privacy/client.tsx
@@ -88,7 +88,7 @@ export default function PrivacyPolicy() {
                             <li>{t.privacy.sections.contact.items.discord}</li>
                             <li>
                                 {t.privacy.sections.contact.items.github}{" "}
-                                <a href="https://github.com/yorunoken/osu-guessr" className="text-primary hover:underline">
+                                <a href="https://github.com/hanami-osu/osu-guessr" className="text-primary hover:underline">
                                     osu-guessr
                                 </a>
                             </li>

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -185,7 +185,7 @@ export default function SettingsClient() {
                                             ))}
                                         </ul>
                                         <div className="mt-2">
-                                            <Link href="https://github.com/yorunoken/osu-guessr/blob/main/docs/API.md" target="_blank" className="inline-block text-primary hover:underline">
+                                            <Link href="https://github.com/hanami-osu/osu-guessr/blob/main/docs/API.md" target="_blank" className="inline-block text-primary hover:underline">
                                                 {t.settings.apiKeys.actions.viewDocs} →
                                             </Link>
                                         </div>

--- a/src/app/tos/client.tsx
+++ b/src/app/tos/client.tsx
@@ -76,7 +76,7 @@ export default function TosPolicy() {
                             <li>{t.tos.sections.contact.items.discord}</li>
                             <li>
                                 {t.tos.sections.contact.items.github}{" "}
-                                <a href="https://github.com/yorunoken/osu-guessr" className="text-primary hover:underline">
+                                <a href="https://github.com/hanami-osu/osu-guessr" className="text-primary hover:underline">
                                     osu-guessr
                                 </a>
                             </li>


### PR DESCRIPTION
Project setup, translation, API, environment, and repository links now match the current codebase and canonical repository.

- updates the stack to Next.js 16, React 19, Bun, MariaDB, and Redis
- lists all six supported languages and fixes the translation-guide path and numbering
- removes the nonexistent game-flow link and obsolete `SERVER_PORT` example
- documents current API defaults, variants, serialized response shapes, status codes, and the 120-request/60-second rate limit present on `main`
- documents that `DISCORD_WEBHOOK` is optional, reports remain stored when it is unset, and it only controls Discord notifications
- replaces old GitHub owner links in docs, redirects, changelogs, settings, legal pages, and error pages
- prominently warns that `init.sql` drops existing tables and is only for a fresh disposable development database

**Validation**

The branch previously passed:

- `bun install --frozen-lockfile`
- `bun run check`
- `bun test` (55 tests)
- `bun run build`

API examples were rechecked against the implementation after PR #38 merged. The optional-webhook wording was updated after PR #39 merged.

**Remaining limitation**

A proper migration-based installation path remains separate work. This PR intentionally does not modify or replace `init.sql`.