### PR TITLE
chore(docker): improve health checks and CI gating

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,8 +13,36 @@ env:
   IMAGE_NAME: yorunoken/osu-guessr
 
 jobs:
+  quality:
+    name: Check, test, and build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check
+        run: bun run check
+
+      - name: Test
+        run: bun test
+
+      - name: Build
+        run: bun run build
+
   docker:
     name: Build and publish Docker image
+    needs: quality
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
+RUN mkdir -p /app/mapsets/audio /app/mapsets/backgrounds /app/mapsets/skins /app/tmp \
+    && chown -R nextjs:nodejs /app/mapsets /app/tmp
+
 USER nextjs
 
 EXPOSE 3000

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,6 +4,8 @@
 
 `GET /api/health` checks both Redis and MariaDB with short timeouts. It returns `200` only when both required dependencies are available and `503` otherwise. The response includes the deployment ID and simple per-dependency `ok` or `unavailable` states; it does not include credentials, connection strings, or internal exception messages.
 
+The response stops waiting for either dependency after two seconds. This bounds the health request, but it does not cancel an underlying Redis or MariaDB operation that ignores or does not support cancellation; that operation may settle later in the background.
+
 The container health check calls this endpoint, so an unavailable database or Redis instance makes the container unhealthy.
 
 ## Runtime directories
@@ -31,4 +33,4 @@ Create host bind-mount directories with appropriate ownership and permissions be
 
 ## Publishing checks
 
-The Docker publishing workflow runs `bun run check`, `bun test`, and `bun run build` before the Docker job. Image login, build, and push steps do not run when the quality job fails.
+The Docker publishing workflow runs `bun run check`, `bun test`, and `bun run build` before the Docker job. The check command generates Prisma Client before linting and type-checking, so it also works from a clean checkout. Image login, build, and push steps do not run when the quality job fails.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,34 @@
+# Deployment notes
+
+## Health checks
+
+`GET /api/health` checks both Redis and MariaDB with short timeouts. It returns `200` only when both required dependencies are available and `503` otherwise. The response includes the deployment ID and simple per-dependency `ok` or `unavailable` states; it does not include credentials, connection strings, or internal exception messages.
+
+The container health check calls this endpoint, so an unavailable database or Redis instance makes the container unhealthy.
+
+## Runtime directories
+
+The runtime image creates these writable directories for the non-root `nextjs` user (UID/GID 1001):
+
+- `/app/mapsets/audio`
+- `/app/mapsets/backgrounds`
+- `/app/mapsets/skins`
+- `/app/tmp`
+
+Imported media under `/app/mapsets` should normally be backed by persistent storage. A bind mount or named volume must be writable by UID/GID 1001. The `/app/tmp` directory can remain ephemeral unless an operator has a specific recovery requirement.
+
+Example volume layout:
+
+```yaml
+services:
+  app:
+    volumes:
+      - ./mapsets:/app/mapsets
+      - ./tmp:/app/tmp
+```
+
+Create host bind-mount directories with appropriate ownership and permissions before starting the container. Do not make them world-writable as a shortcut.
+
+## Publishing checks
+
+The Docker publishing workflow runs `bun run check`, `bun test`, and `bun run build` before the Docker job. Image login, build, and push steps do not run when the quality job fails.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "dev": "dotenv -e .env -- next dev",
         "build": "prisma generate && IS_DOCKER_BUILD=true next build",
         "start": "dotenv -e .env -- next start",
-        "check": "eslint src && tsc --noEmit",
+        "check": "prisma generate && eslint src && tsc --noEmit",
         "test": "bun test",
         "sync": "bun scripts/sync-translations",
         "prisma:generate": "prisma generate",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,8 +1,16 @@
 import { NextResponse } from "next/server";
+import redisClient from "@/lib/redis";
+import { query } from "@/lib/database";
+import { getApplicationHealth } from "@/lib/health";
 
-export function GET() {
-    return NextResponse.json({
-        ok: true,
-        deploymentId: process.env.NEXT_DEPLOYMENT_ID || null,
-    });
+export async function GET() {
+    const health = await getApplicationHealth(
+        {
+            redisPing: () => redisClient.ping(),
+            mariaDbPing: () => query("SELECT 1"),
+        },
+        process.env.NEXT_DEPLOYMENT_ID
+    );
+
+    return NextResponse.json(health.body, { status: health.status });
 }

--- a/src/lib/health.test.ts
+++ b/src/lib/health.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { getApplicationHealth } from "./health";
+
+describe("getApplicationHealth", () => {
+    test("returns 200 with dependency status and deployment ID when healthy", async () => {
+        const result = await getApplicationHealth(
+            {
+                redisPing: async () => "PONG",
+                mariaDbPing: async () => [{ ok: 1 }],
+            },
+            "deployment-123"
+        );
+
+        expect(result).toEqual({
+            status: 200,
+            body: {
+                ok: true,
+                deploymentId: "deployment-123",
+                dependencies: { redis: "ok", mariadb: "ok" },
+            },
+        });
+    });
+
+    test("checks both dependencies and returns 503 when Redis fails", async () => {
+        let mariaDbChecked = false;
+        const result = await getApplicationHealth(
+            {
+                redisPing: async () => {
+                    throw new Error("redis://user:secret@internal:6379 failed");
+                },
+                mariaDbPing: async () => {
+                    mariaDbChecked = true;
+                },
+            },
+            undefined
+        );
+
+        expect(mariaDbChecked).toBe(true);
+        expect(result.status).toBe(503);
+        expect(result.body).toEqual({
+            ok: false,
+            deploymentId: null,
+            dependencies: { redis: "unavailable", mariadb: "ok" },
+        });
+        expect(JSON.stringify(result)).not.toContain("secret");
+    });
+
+    test("returns 503 when MariaDB fails or a dependency times out", async () => {
+        const databaseFailure = await getApplicationHealth(
+            {
+                redisPing: async () => "PONG",
+                mariaDbPing: async () => {
+                    throw new Error("database unavailable");
+                },
+            },
+            "deployment"
+        );
+        const timeout = await getApplicationHealth(
+            {
+                redisPing: () => new Promise(() => {}),
+                mariaDbPing: async () => undefined,
+            },
+            "deployment",
+            5
+        );
+
+        expect(databaseFailure.status).toBe(503);
+        expect(databaseFailure.body.dependencies.mariadb).toBe("unavailable");
+        expect(timeout.status).toBe(503);
+        expect(timeout.body.dependencies.redis).toBe("unavailable");
+    });
+});

--- a/src/lib/health.ts
+++ b/src/lib/health.ts
@@ -1,0 +1,47 @@
+export type DependencyHealth = "ok" | "unavailable";
+
+interface HealthDependencies {
+    redisPing(): Promise<unknown>;
+    mariaDbPing(): Promise<unknown>;
+}
+
+export interface HealthPayload {
+    ok: boolean;
+    deploymentId: string | null;
+    dependencies: {
+        redis: DependencyHealth;
+        mariadb: DependencyHealth;
+    };
+}
+
+async function checkWithTimeout(check: () => Promise<unknown>, timeoutMs: number): Promise<DependencyHealth> {
+    return new Promise((resolve) => {
+        let settled = false;
+        const finish = (status: DependencyHealth) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve(status);
+        };
+        const timer = setTimeout(() => finish("unavailable"), timeoutMs);
+
+        Promise.resolve()
+            .then(check)
+            .then(() => finish("ok"))
+            .catch(() => finish("unavailable"));
+    });
+}
+
+export async function getApplicationHealth(dependencies: HealthDependencies, deploymentId: string | undefined, timeoutMs: number = 2000): Promise<{ status: 200 | 503; body: HealthPayload }> {
+    const [redis, mariadb] = await Promise.all([checkWithTimeout(dependencies.redisPing, timeoutMs), checkWithTimeout(dependencies.mariaDbPing, timeoutMs)]);
+    const ok = redis === "ok" && mariadb === "ok";
+
+    return {
+        status: ok ? 200 : 503,
+        body: {
+            ok,
+            deploymentId: deploymentId || null,
+            dependencies: { redis, mariadb },
+        },
+    };
+}


### PR DESCRIPTION
Runtime health, writable import directories, deployment guidance, and Docker publishing gates cover the application’s required dependencies and quality checks.

- probes Redis and MariaDB concurrently and returns the health response after a two-second deadline
- returns 200 only when both dependencies are healthy and 503 otherwise
- exposes only deployment ID and per-dependency `ok`/`unavailable` states
- keeps the Docker health check on `/api/health`
- creates mapset audio/background/skin and temporary directories with `nextjs:nodejs` ownership before dropping privileges
- documents persistent media volumes and UID/GID 1001 bind-mount requirements
- makes `bun run check` generate Prisma Client before lint/type-check so the command works from a clean checkout
- requires check, test, and build to succeed before the Docker job
- preserves existing image names, tags, triggers, credentials, and PR no-push behavior

**CI failure and fix**

The previous GitHub Actions run failed in `bun run check` with `TS2307: Cannot find module '@/generated/prisma/client'`; tests and build were skipped, and the Docker job was correctly blocked. The updated check command generates Prisma Client first. The failure was reproduced from a clean local checkout, and the same checkout passed after the fix.

**Local tests**

- `bun install --frozen-lockfile` — passed, no lockfile changes
- `bun run check` — passed, including Prisma generation from a clean checkout
- `bun test` — passed (58 tests)
- `bun run build` — passed

**GitHub Actions**

[Docker Publish run #32](https://github.com/hanami-osu/osu-guessr/actions/runs/29213638669) passed completely on the updated branch:

- quality install/check/test/build job — passed
- dependent Docker build job — passed
- Docker Hub login and Server Actions key verification — skipped for the PR event
- image push — disabled for the PR event

**Operational limitation**

The health response stops waiting after two seconds, but Redis or MariaDB operations that do not support cancellation may settle later. Host bind-mount ownership must still be prepared by the operator.