### PR TITLE
fix(importer): validate imported media formats

### DIFF
--- a/src/actions/game-server.ts
+++ b/src/actions/game-server.ts
@@ -9,6 +9,7 @@ import { getRandomAudioAction, getRandomBackgroundAction, getRandomSkinAction } 
 import { GameMode, type MapsetDataWithTags, type GameState, type DatabaseGameSession, type SkinData } from "./types";
 import { getMediaData } from "./media";
 import { checkGuess, GuessDifficulty } from "@/lib/guess-checker";
+import { isNoGameContentError } from "@/lib/game/content-errors";
 
 const GRACE_PERIOD = 1;
 const SESSION_LOCK_TTL_MS = 5000;
@@ -208,7 +209,7 @@ export async function submitGuessAction(sessionId: string, guess?: string | null
         const currentMedia: { backgroundData?: string; audioData?: string; skinData?: string } = {};
         if (gameState.game_mode === GameMode.Background) {
             currentMedia.backgroundData = await getMediaData(GameMode.Background, gameState.image_filename);
-        } else if (gameState.game_mode === GameMode.Audio && gameState.audio_filename) {
+        } else if (gameState.game_mode === GameMode.Audio) {
             currentMedia.audioData = await getMediaData(GameMode.Audio, gameState.audio_filename);
         } else if (gameState.game_mode === GameMode.Skin) {
             currentMedia.skinData = await getMediaData(GameMode.Skin, gameState.image_filename);
@@ -229,7 +230,9 @@ export async function submitGuessAction(sessionId: string, guess?: string | null
                 } else if (gameState.game_mode === GameMode.Skin) {
                     await getRandomSkinAction(validated.sessionId);
                 }
-            } catch {
+            } catch (error) {
+                if (!isNoGameContentError(error)) throw error;
+
                 // No more beatmaps: end game and return finished state
                 const newStreak = gameState.current_streak + 1;
                 const newHighest = Math.max(gameState.highest_streak, newStreak);
@@ -355,7 +358,7 @@ export async function submitGuessAction(sessionId: string, guess?: string | null
                     };
                 }
             } catch (error) {
-                if (!isDeathMode) throw error;
+                if (!isDeathMode || !isNoGameContentError(error)) throw error;
                 await endGameAction(sessionId);
                 return {
                     sessionId,
@@ -489,7 +492,7 @@ export async function getGameStateAction(sessionId: string): Promise<GameState> 
         let mediaData: string | undefined;
         if (gameState.game_mode === GameMode.Background) {
             mediaData = await getMediaData(GameMode.Background, gameState.image_filename);
-        } else if (gameState.game_mode === GameMode.Audio && gameState.audio_filename) {
+        } else if (gameState.game_mode === GameMode.Audio) {
             mediaData = await getMediaData(GameMode.Audio, gameState.audio_filename);
         } else if (gameState.game_mode === GameMode.Skin) {
             mediaData = await getMediaData(GameMode.Skin, gameState.image_filename);

--- a/src/actions/mapsets-server.ts
+++ b/src/actions/mapsets-server.ts
@@ -7,12 +7,13 @@ import { authenticatedAction } from "./server";
 import { getMediaData } from "./media";
 
 import { GameMode, type MapsetTags, type MapsetData, type MapsetDataWithTags, type SkinData } from "./types";
+import { NoGameContentError } from "@/lib/game/content-errors";
 
 export async function getRandomAudioAction(sessionId?: string) {
     return authenticatedAction(async () => {
         const audio = await getRandomAudio(sessionId);
         if (!audio) {
-            throw new Error("No audio found");
+            throw new NoGameContentError("No audio found");
         }
 
         const audioData = await getMediaData(GameMode.Audio, audio.audio_filename);
@@ -38,6 +39,7 @@ async function getRandomAudio(sessionId?: string): Promise<MapsetDataWithTags | 
     const tagResults: Array<MapsetTags> = await query(
         `SELECT * FROM mapset_tags
             WHERE audio_filename IS NOT NULL
+            AND audio_filename <> ''
             AND mapset_id NOT IN (${excludedIds.length ? excludedIds.map(() => "?").join(",") : "0"})
             ORDER BY RAND() LIMIT 1;`,
         excludedIds
@@ -76,7 +78,7 @@ export async function getRandomBackgroundAction(sessionId?: string) {
     return authenticatedAction(async () => {
         const background = await getRandomBackground(sessionId);
         if (!background) {
-            throw new Error("No background found");
+            throw new NoGameContentError("No background found");
         }
 
         const backgroundImageData = await getMediaData(GameMode.Background, background.image_filename);
@@ -102,6 +104,8 @@ async function getRandomBackground(sessionId?: string): Promise<MapsetDataWithTa
     const tagResults: Array<MapsetTags> = await query(
         `SELECT * FROM mapset_tags
             WHERE mapset_id IS NOT NULL
+            AND image_filename IS NOT NULL
+            AND image_filename <> ''
             AND mapset_id NOT IN (${excludedIds.length ? excludedIds.map(() => "?").join(",") : "0"})
             ORDER BY RAND() LIMIT 1;`,
         excludedIds
@@ -146,7 +150,7 @@ export async function getRandomSkinAction(sessionId?: string) {
     return authenticatedAction(async () => {
         const skin = await getRandomSkin(sessionId);
         if (!skin) {
-            throw new Error("No skin found");
+            throw new NoGameContentError("No skin found");
         }
 
         const skinData = await getMediaData(GameMode.Skin, skin.image_filename);
@@ -168,13 +172,15 @@ async function getRandomSkin(sessionId?: string): Promise<SkinData | null> {
             excludedIds = cached.map((id) => Number(id)).filter(Boolean);
         }
     }
-    const condition = excludedIds.length > 0 ? `WHERE id NOT IN (${excludedIds.map(() => "?").join(",")})` : "";
+    const excludedCondition = excludedIds.length > 0 ? `AND id NOT IN (${excludedIds.map(() => "?").join(",")})` : "";
     const params = excludedIds;
 
     const result = await query(
         `SELECT * 
          FROM skins
-         ${condition}
+         WHERE image_filename IS NOT NULL
+         AND image_filename <> ''
+         ${excludedCondition}
          ORDER BY RAND()
          LIMIT 1`,
         params

--- a/src/actions/media.test.ts
+++ b/src/actions/media.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { GameMode } from "./types";
+import { getMediaData } from "./media";
+import { MediaUnavailableError } from "@/lib/media-format";
+
+describe("getMediaData", () => {
+    test("returns a controlled error when selected media is missing", async () => {
+        const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+        try {
+            await expect(getMediaData(GameMode.Background, "missing-import-test.webp")).rejects.toBeInstanceOf(MediaUnavailableError);
+        } finally {
+            consoleError.mockRestore();
+        }
+    });
+});

--- a/src/actions/media.ts
+++ b/src/actions/media.ts
@@ -1,32 +1,30 @@
 import path from "path";
 import fs from "fs/promises";
 import { GameMode } from "./types";
+import { getMediaMimeType, MediaUnavailableError } from "@/lib/media-format";
 
-export async function getMediaData(gameMode: GameMode, filename: string | null): Promise<string | undefined> {
-    if (!filename) return undefined;
+export async function getMediaData(gameMode: GameMode, filename: string | null): Promise<string> {
+    if (!filename) throw new MediaUnavailableError();
 
     try {
         let filePath: string;
-        let mimeType: string;
 
         if (gameMode === GameMode.Background) {
             filePath = path.join(process.cwd(), "mapsets", "backgrounds", filename);
-            mimeType = "image/jpeg";
         } else if (gameMode === GameMode.Audio) {
             filePath = path.join(process.cwd(), "mapsets", "audio", filename);
-            const fileExtension = path.extname(filename).toLowerCase();
-            mimeType = fileExtension === ".ogg" ? "audio/ogg" : "audio/mp3";
         } else if (gameMode === GameMode.Skin) {
             filePath = path.join(process.cwd(), "mapsets", "skins", filename);
-            mimeType = "image/jpeg"; // Depending on how skins are saved, could be png, but assuming jpeg based on existing code
         } else {
-            return undefined;
+            throw new MediaUnavailableError();
         }
 
+        const mimeType = getMediaMimeType(gameMode, filename);
         const buffer = await fs.readFile(filePath);
         return `data:${mimeType};base64,${buffer.toString("base64")}`;
     } catch (error) {
         console.error(`Failed to load media for ${gameMode} with filename ${filename}:`, error);
-        return undefined;
+        if (error instanceof MediaUnavailableError) throw error;
+        throw new MediaUnavailableError();
     }
 }

--- a/src/app/admin/actions/mapsets.ts
+++ b/src/app/admin/actions/mapsets.ts
@@ -12,7 +12,7 @@ import sharp from "sharp";
 import { z } from "zod";
 import { env } from "@/lib/env";
 import { requireOwner } from "@/actions/require-owner";
-import { selectAudioImportFile, type AudioImportCandidate } from "@/lib/importer-validation";
+import { isMp3File, selectAudioImportFile, type AudioImportCandidate } from "@/lib/importer-validation";
 
 const DIRECTORIES = {
     audio: path.join(process.cwd(), "mapsets", "audio"),
@@ -266,7 +266,11 @@ async function findLargestAudioFile(mapsetDir: string): Promise<string> {
 
         const stats = await fs.stat(path.join(mapsetDir, file));
         if (stats.isFile()) {
-            candidates.push({ name: file, size: stats.size });
+            candidates.push({
+                name: file,
+                size: stats.size,
+                isValidMp3: path.extname(file).toLowerCase() === ".mp3" && (await isMp3File(path.join(mapsetDir, file))),
+            });
         }
     }
 

--- a/src/app/admin/actions/mapsets.ts
+++ b/src/app/admin/actions/mapsets.ts
@@ -12,6 +12,7 @@ import sharp from "sharp";
 import { z } from "zod";
 import { env } from "@/lib/env";
 import { requireOwner } from "@/actions/require-owner";
+import { selectAudioImportFile, type AudioImportCandidate } from "@/lib/importer-validation";
 
 const DIRECTORIES = {
     audio: path.join(process.cwd(), "mapsets", "audio"),
@@ -35,6 +36,12 @@ export interface Mapset {
     mapper: string;
     image_filename: string;
     audio_filename: string;
+}
+
+interface AddMapsetResult {
+    success: boolean;
+    note?: "already_exists";
+    error?: string;
 }
 
 interface BeatmapData {
@@ -249,54 +256,32 @@ async function extractBackground(mapsetId: number): Promise<string | null> {
 }
 
 // Audio Processing
-async function findLargestAudioFile(mapsetDir: string): Promise<string | null> {
-    try {
-        const files = await fs.readdir(mapsetDir);
-        const audioExtensions = [".mp3", ".ogg", ".wav"];
+async function findLargestAudioFile(mapsetDir: string): Promise<string> {
+    const files = await fs.readdir(mapsetDir);
+    const audioExtensions = new Set([".mp3", ".ogg", ".wav"]);
+    const candidates: AudioImportCandidate[] = [];
 
-        let largestAudio: string | null = null;
-        let largestSize = 0;
+    for (const file of files) {
+        if (!audioExtensions.has(path.extname(file).toLowerCase())) continue;
 
-        for (const file of files) {
-            const hasAudioExtension = audioExtensions.some((ext) => file.toLowerCase().endsWith(ext));
-
-            if (hasAudioExtension) {
-                const filePath = path.join(mapsetDir, file);
-                const stats = await fs.stat(filePath);
-
-                if (stats.size > largestSize) {
-                    largestSize = stats.size;
-                    largestAudio = file;
-                }
-            }
+        const stats = await fs.stat(path.join(mapsetDir, file));
+        if (stats.isFile()) {
+            candidates.push({ name: file, size: stats.size });
         }
-
-        return largestAudio;
-    } catch (error) {
-        console.error("Error finding audio files:", error);
-        return null;
     }
+
+    return selectAudioImportFile(candidates);
 }
 
-async function extractAudio(mapsetId: number, mapsetDir: string): Promise<string | null> {
-    try {
-        const largestAudio = await findLargestAudioFile(mapsetDir);
-        if (!largestAudio) {
-            throw new Error("No audio files found");
-        }
+async function extractAudio(mapsetId: number, mapsetDir: string): Promise<string> {
+    const largestAudio = await findLargestAudioFile(mapsetDir);
+    const srcPath = path.join(mapsetDir, largestAudio);
+    const audioFilename = `${mapsetId}.mp3`;
+    const destPath = path.join(DIRECTORIES.audio, audioFilename);
 
-        const srcPath = path.join(mapsetDir, largestAudio);
-        const audioFilename = `${mapsetId}.mp3`;
-        const destPath = path.join(DIRECTORIES.audio, audioFilename);
+    await fs.copyFile(srcPath, destPath);
 
-        // For now, just copy the file - you can add ffmpeg processing later
-        await fs.copyFile(srcPath, destPath);
-
-        return audioFilename;
-    } catch (error) {
-        console.error(`Error processing audio for mapset ${mapsetId}:`, error);
-        return null;
-    }
+    return audioFilename;
 }
 
 async function saveMapsetToDatabase(mapsetId: number, beatmapData: BeatmapData, imageFilename: string, audioFilename: string): Promise<void> {
@@ -338,7 +323,7 @@ async function removeMapsetFromDatabase(mapsetId: number): Promise<void> {
     await query("DELETE FROM mapset_data WHERE mapset_id = ?", [mapsetId]);
 }
 
-export async function addMapset(rawMapsetId: number): Promise<{ success: boolean; note?: string }> {
+export async function addMapset(rawMapsetId: number): Promise<AddMapsetResult> {
     await requireOwner();
     const mapsetId = z.coerce.number().min(1).parse(rawMapsetId);
     console.log(`Processing mapset ID: ${mapsetId}`);
@@ -379,8 +364,9 @@ export async function addMapset(rawMapsetId: number): Promise<{ success: boolean
         console.log(`Successfully added mapset ${mapsetId}`);
         return { success: true };
     } catch (error) {
-        console.error(`Error adding mapset ${mapsetId}:`, error);
-        throw error;
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        console.error(`Error adding mapset ${mapsetId}:`, errorMessage);
+        return { success: false, error: errorMessage };
     }
 }
 
@@ -419,9 +405,14 @@ export async function addMapsetFromList(fileContent: string) {
                 results.push({ id: mapsetId, success: true, note: "already_exists" });
                 console.log(`→ Mapset ${mapsetId}: Already exists in database. Skipping.`);
             } else {
-                await addMapset(mapsetId);
-                results.push({ id: mapsetId, success: true });
-                console.log(`✓ Mapset ${mapsetId}: Successfully added`);
+                const result = await addMapset(mapsetId);
+                if (result.success) {
+                    results.push({ id: mapsetId, success: true, note: result.note });
+                    console.log(`✓ Mapset ${mapsetId}: Successfully added`);
+                } else {
+                    results.push({ id: mapsetId, success: false, error: result.error });
+                    console.log(`✗ Mapset ${mapsetId}: Failed - ${result.error}`);
+                }
             }
         } catch (error) {
             results.push({ id: mapsetId, success: false, error: String(error) });

--- a/src/app/admin/actions/skins.ts
+++ b/src/app/admin/actions/skins.ts
@@ -2,13 +2,12 @@
 
 import { query } from "@/lib/database";
 import fs from "fs/promises";
-import fsSync from "fs";
 import path from "path";
-import { pipeline } from "stream/promises";
-import { Readable } from "stream";
 import { z } from "zod";
 import { env } from "@/lib/env";
 import { requireOwner } from "@/actions/require-owner";
+import { parseSkinApiResponse, type SkinImportData } from "@/lib/skin-import";
+import sharp from "sharp";
 
 const DIRECTORIES = {
     skins: path.join(process.cwd(), "mapsets", "skins"),
@@ -18,30 +17,6 @@ const DIRECTORIES = {
 const OSUCK_API_KEY = env.OSUCK_API_KEY;
 const OSUCK_API_BASE_URL = env.OSUCK_API_BASE;
 const MAX_BULK_SKINS = 50;
-
-interface SkinData {
-    _nsfw: boolean;
-    id: number;
-    name: string;
-    gamemodes: number[];
-    screenshots: Array<{
-        // 2 = song select
-        // 6 = gameplay
-        // 10 = pause screen
-        // 12 = result screen
-        category: number;
-        gamemode: number;
-        large: string;
-        medium: string;
-        small: string;
-    }>;
-    link_to_skin: string;
-}
-
-interface ApiResponse {
-    status: "success" | "failed";
-    message: "rate limited" | "no api key" | "invalid api key" | SkinData;
-}
 
 interface SkinProcessResult {
     success: boolean;
@@ -62,17 +37,9 @@ async function ensureDirectories(): Promise<void> {
     await Promise.all(directories.map((dir) => fs.mkdir(dir, { recursive: true })));
 }
 
-async function cleanupDirectory(dirPath: string): Promise<void> {
-    try {
-        await fs.rm(dirPath, { recursive: true, force: true });
-    } catch (error) {
-        console.warn(`Failed to cleanup directory ${dirPath}:`, error);
-    }
-}
-
-async function fetchSkinMetadata(skinId: number): Promise<SkinData | null> {
-    if (!OSUCK_API_KEY) {
-        throw new Error("OSUCK_API_KEY environment variable is not set");
+async function fetchSkinMetadata(skinId: number): Promise<SkinImportData> {
+    if (!OSUCK_API_KEY || !OSUCK_API_BASE_URL) {
+        throw new Error("The osu!ck API integration is not configured");
     }
 
     try {
@@ -90,22 +57,14 @@ async function fetchSkinMetadata(skinId: number): Promise<SkinData | null> {
             throw new Error(`API request failed: ${response.status}`);
         }
 
-        const data = (await response.json()) as ApiResponse;
-
-        if (data.status === "failed") {
-            const errorMessage = typeof data.message === "string" ? data.message : "Unknown API error";
-            throw new Error(`API error: ${errorMessage}`);
-        }
-
-        const msg = data.message as SkinData;
-        return msg;
+        return parseSkinApiResponse(await response.json(), skinId);
     } catch (error) {
         console.error(`Failed to fetch skin metadata for ${skinId} :`, error);
-        return null;
+        throw error;
     }
 }
 
-async function downloadSkin(skinData: SkinData): Promise<string | null> {
+async function downloadSkin(skinData: SkinImportData): Promise<string> {
     const gameplayCategory = skinData.screenshots.find((screenshot) => screenshot.category === 6); // 6 is for the gameplay category of the skin
     if (!gameplayCategory) {
         throw new Error("No gameplay screenshot found for this skin");
@@ -121,22 +80,17 @@ async function downloadSkin(skinData: SkinData): Promise<string | null> {
             throw new Error(`Failed to download screenshot: ${response.status}`);
         }
 
-        if (!response.body) {
-            throw new Error("No response body for screenshot download");
-        }
-
-        // @ts-expect-error idk why
-        const nodeStream = Readable.fromWeb(response.body);
-        await pipeline(nodeStream, fsSync.createWriteStream(imagePath));
+        const downloadedImage = Buffer.from(await response.arrayBuffer());
+        await sharp(downloadedImage).webp({ quality: 80 }).toFile(imagePath);
 
         return fileName;
     } catch (error) {
         console.error(`Error downloading screenshot for skin ${skinData.id}:`, error);
-        return null;
+        throw error;
     }
 }
 
-async function saveSkinToDatabase(skinData: SkinData, imageFilename: string): Promise<void> {
+async function saveSkinToDatabase(skinData: SkinImportData, imageFilename: string): Promise<void> {
     await query(
         `INSERT INTO skins (id, name, image_filename)
      VALUES (?, ?, ?)`,
@@ -156,18 +110,10 @@ export async function addSkinById(rawSkinId: number): Promise<SkinProcessResult>
     try {
         await ensureDirectories();
         const skinData = await fetchSkinMetadata(skinId);
-        if (!skinData) {
-            throw new Error("Could not fetch skin metadata from API");
-        }
 
         const skinFileName = await downloadSkin(skinData);
-        if (!skinFileName) {
-            throw new Error("Failed to download and extract skin");
-        }
 
         await saveSkinToDatabase(skinData, skinFileName);
-
-        await cleanupDirectory(skinFileName);
 
         return {
             success: true,
@@ -189,20 +135,15 @@ export async function addSkinsFromList(rawIds: number[]): Promise<Array<{ id: nu
     await requireOwner();
     const ids = z.array(z.coerce.number().min(1)).max(MAX_BULK_SKINS).parse(rawIds);
     const results: Array<{ id: number; success: boolean; error?: string; image?: string }> = [];
+    await ensureDirectories();
 
     for (const [index, id] of ids.entries()) {
         console.log(`Processing skin ${index + 1}/${ids.length}: ${id}`);
 
         try {
             const skinData = await fetchSkinMetadata(id);
-            if (!skinData) {
-                throw new Error("Could not fetch skin metadata from API");
-            }
 
             const image = await downloadSkin(skinData);
-            if (!image) {
-                throw new Error("Failed to download image");
-            }
 
             await saveSkinToDatabase(skinData, image);
 

--- a/src/app/admin/menu.tsx
+++ b/src/app/admin/menu.tsx
@@ -159,7 +159,7 @@ export default function AdminMenu() {
             } else if (res?.success) {
                 appendOutput("Mapset added successfully");
             } else {
-                appendOutput(`Mapset add returned unexpected response: ${JSON.stringify(res)}`);
+                appendOutput(`Error: ${res?.error ?? "Mapset import failed"}`);
             }
         } catch (error) {
             appendOutput(`Error: ${error}`);

--- a/src/app/games/audio/components/GameAudio.tsx
+++ b/src/app/games/audio/components/GameAudio.tsx
@@ -108,7 +108,7 @@ export default function GameAudio({ mediaUrl, isRevealed, result, songInfo, onVo
                     </div>
                 )}
                 <audio ref={audioRef} controls className={`w-full mb-4 ${isLoading || mediaError ? "hidden" : "block"}`}>
-                    <source src={mediaUrl} type="audio/mp3" />
+                    <source src={mediaUrl} />
                     {t.game.audio.browserNotSupported}
                 </audio>
                 {!isRevealed && <p className="text-center text-muted-foreground">{t.game.audio.instructions}</p>}

--- a/src/lib/game/content-errors.test.ts
+++ b/src/lib/game/content-errors.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { MediaUnavailableError } from "@/lib/media-format";
+import { isNoGameContentError, NoGameContentError } from "./content-errors";
+
+describe("content exhaustion errors", () => {
+    test("does not treat media failures as exhausted game content", () => {
+        expect(isNoGameContentError(new NoGameContentError("No background found"))).toBe(true);
+        expect(isNoGameContentError(new MediaUnavailableError())).toBe(false);
+    });
+});

--- a/src/lib/game/content-errors.ts
+++ b/src/lib/game/content-errors.ts
@@ -1,0 +1,10 @@
+export class NoGameContentError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "NoGameContentError";
+    }
+}
+
+export function isNoGameContentError(error: unknown): error is NoGameContentError {
+    return error instanceof NoGameContentError;
+}

--- a/src/lib/importer-validation.test.ts
+++ b/src/lib/importer-validation.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, test } from "bun:test";
-import { selectAudioImportFile, UnsupportedAudioFormatError } from "./importer-validation";
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { isMp3File, selectAudioImportFile, UnsupportedAudioFormatError } from "./importer-validation";
 import { parseSkinApiResponse } from "./skin-import";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+    await Promise.all(temporaryDirectories.splice(0).map((directory) => fs.rm(directory, { recursive: true, force: true })));
+});
+
+function createMp3Fixture(withId3Tag = false): Uint8Array {
+    const frameLength = 417;
+    const audioOffset = withId3Tag ? 10 : 0;
+    const fixture = new Uint8Array(audioOffset + frameLength * 2);
+    const frameHeader = [0xff, 0xfb, 0x90, 0x64];
+    if (withId3Tag) fixture.set([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], 0);
+    fixture.set(frameHeader, audioOffset);
+    fixture.set(frameHeader, audioOffset + frameLength);
+    return fixture;
+}
 
 const validSkinResponse = {
     status: "success",
@@ -26,12 +46,31 @@ describe("importer file validation", () => {
     test("selects the largest MP3 without renaming OGG or WAV data", () => {
         expect(
             selectAudioImportFile([
-                { name: "large.ogg", size: 5000 },
-                { name: "small.mp3", size: 1000 },
-                { name: "large.mp3", size: 2000 },
+                { name: "large.ogg", size: 5000, isValidMp3: false },
+                { name: "small.mp3", size: 1000, isValidMp3: true },
+                { name: "renamed.mp3", size: 3000, isValidMp3: false },
+                { name: "large.mp3", size: 2000, isValidMp3: true },
             ])
         ).toBe("large.mp3");
-        expect(() => selectAudioImportFile([{ name: "audio.wav", size: 1000 }])).toThrow(UnsupportedAudioFormatError);
+        expect(() => selectAudioImportFile([{ name: "audio.wav", size: 1000, isValidMp3: false }])).toThrow(UnsupportedAudioFormatError);
+    });
+
+    test("validates MP3 content instead of trusting an .mp3 extension", async () => {
+        const directory = await fs.mkdtemp(path.join(os.tmpdir(), "osu-guessr-audio-"));
+        temporaryDirectories.push(directory);
+        const genuineMp3 = path.join(directory, "genuine.mp3");
+        const renamedOgg = path.join(directory, "renamed-ogg.mp3");
+        const renamedWav = path.join(directory, "renamed-wav.mp3");
+
+        await Promise.all([
+            fs.writeFile(genuineMp3, createMp3Fixture(true)),
+            fs.writeFile(renamedOgg, new Uint8Array([0x4f, 0x67, 0x67, 0x53, 0x00, 0x02, 0x00, 0x00])),
+            fs.writeFile(renamedWav, new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45])),
+        ]);
+
+        expect(await isMp3File(genuineMp3)).toBe(true);
+        expect(await isMp3File(renamedOgg)).toBe(false);
+        expect(await isMp3File(renamedWav)).toBe(false);
     });
 
     test("validates skin API data and rejects NSFW or malformed metadata", () => {

--- a/src/lib/importer-validation.test.ts
+++ b/src/lib/importer-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { selectAudioImportFile, UnsupportedAudioFormatError } from "./importer-validation";
+import { parseSkinApiResponse } from "./skin-import";
+
+const validSkinResponse = {
+    status: "success",
+    message: {
+        _nsfw: false,
+        id: 42,
+        name: "Example Skin",
+        gamemodes: [0],
+        screenshots: [
+            {
+                category: 6,
+                gamemode: 0,
+                large: "https://example.com/large.png",
+                medium: "https://example.com/medium.png",
+                small: "https://example.com/small.png",
+            },
+        ],
+        link_to_skin: "https://example.com/skin.osk",
+    },
+} as const;
+
+describe("importer file validation", () => {
+    test("selects the largest MP3 without renaming OGG or WAV data", () => {
+        expect(
+            selectAudioImportFile([
+                { name: "large.ogg", size: 5000 },
+                { name: "small.mp3", size: 1000 },
+                { name: "large.mp3", size: 2000 },
+            ])
+        ).toBe("large.mp3");
+        expect(() => selectAudioImportFile([{ name: "audio.wav", size: 1000 }])).toThrow(UnsupportedAudioFormatError);
+    });
+
+    test("validates skin API data and rejects NSFW or malformed metadata", () => {
+        expect(parseSkinApiResponse(validSkinResponse, 42).name).toBe("Example Skin");
+        expect(() => parseSkinApiResponse({ ...validSkinResponse, message: { ...validSkinResponse.message, _nsfw: true } }, 42)).toThrow("NSFW skins are not allowed");
+        expect(() => parseSkinApiResponse({ ...validSkinResponse, message: { ...validSkinResponse.message, screenshots: [] } }, 42)).toThrow();
+        expect(() => parseSkinApiResponse(validSkinResponse, 7)).toThrow("unexpected skin ID");
+    });
+});

--- a/src/lib/importer-validation.ts
+++ b/src/lib/importer-validation.ts
@@ -1,0 +1,26 @@
+import path from "path";
+
+export interface AudioImportCandidate {
+    name: string;
+    size: number;
+}
+
+export class UnsupportedAudioFormatError extends Error {
+    constructor() {
+        super("This mapset does not contain MP3 audio. OGG and WAV imports are not supported; provide an MP3 source.");
+        this.name = "UnsupportedAudioFormatError";
+    }
+}
+
+export function selectAudioImportFile(candidates: AudioImportCandidate[]): string {
+    const mp3Files = candidates.filter((candidate) => path.extname(candidate.name).toLowerCase() === ".mp3");
+    if (mp3Files.length > 0) {
+        return mp3Files.reduce((largest, candidate) => (candidate.size > largest.size ? candidate : largest)).name;
+    }
+
+    if (candidates.some((candidate) => [".ogg", ".wav"].includes(path.extname(candidate.name).toLowerCase()))) {
+        throw new UnsupportedAudioFormatError();
+    }
+
+    throw new Error("No supported audio file was found in the mapset archive.");
+}

--- a/src/lib/importer-validation.ts
+++ b/src/lib/importer-validation.ts
@@ -1,24 +1,102 @@
 import path from "path";
+import fs from "fs/promises";
+
+const MP3_SCAN_BYTES = 64 * 1024;
+
+const MPEG1_LAYER_3_BITRATES = [0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320] as const;
+const MPEG2_LAYER_3_BITRATES = [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160] as const;
+const MPEG1_SAMPLE_RATES = [44_100, 48_000, 32_000] as const;
 
 export interface AudioImportCandidate {
     name: string;
     size: number;
+    isValidMp3: boolean;
 }
 
 export class UnsupportedAudioFormatError extends Error {
     constructor() {
-        super("This mapset does not contain MP3 audio. OGG and WAV imports are not supported; provide an MP3 source.");
+        super("This mapset does not contain valid MP3 audio. OGG and WAV data are not supported, even when renamed with an .mp3 extension.");
         this.name = "UnsupportedAudioFormatError";
     }
 }
 
+function getMp3FrameLength(data: Uint8Array, offset: number): number | null {
+    if (offset + 4 > data.length) return null;
+
+    const byte1 = data[offset + 1];
+    const byte2 = data[offset + 2];
+    const byte3 = data[offset + 3];
+
+    if (data[offset] !== 0xff || (byte1 & 0xe0) !== 0xe0) return null;
+
+    const versionBits = (byte1 >> 3) & 0x03;
+    const layerBits = (byte1 >> 1) & 0x03;
+    const bitrateIndex = (byte2 >> 4) & 0x0f;
+    const sampleRateIndex = (byte2 >> 2) & 0x03;
+
+    if (versionBits === 0x01 || layerBits !== 0x01 || bitrateIndex === 0 || bitrateIndex === 0x0f || sampleRateIndex === 0x03 || (byte3 & 0x03) === 0x02) {
+        return null;
+    }
+
+    const isMpeg1 = versionBits === 0x03;
+    const bitrate = (isMpeg1 ? MPEG1_LAYER_3_BITRATES : MPEG2_LAYER_3_BITRATES)[bitrateIndex];
+    const sampleRateDivisor = versionBits === 0x03 ? 1 : versionBits === 0x02 ? 2 : 4;
+    const sampleRate = MPEG1_SAMPLE_RATES[sampleRateIndex] / sampleRateDivisor;
+    const padding = (byte2 >> 1) & 0x01;
+
+    return Math.floor(((isMpeg1 ? 144 : 72) * bitrate * 1000) / sampleRate) + padding;
+}
+
+export function hasMp3FrameSequence(data: Uint8Array): boolean {
+    if (data.length >= 4 && String.fromCharCode(...data.subarray(0, 4)) === "OggS") return false;
+    if (data.length >= 12 && String.fromCharCode(...data.subarray(0, 4)) === "RIFF" && String.fromCharCode(...data.subarray(8, 12)) === "WAVE") return false;
+
+    for (let offset = 0; offset + 4 <= data.length; offset += 1) {
+        const frameLength = getMp3FrameLength(data, offset);
+        if (frameLength && getMp3FrameLength(data, offset + frameLength)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function getId3AudioOffset(header: Uint8Array): number | null {
+    if (header.length < 10 || String.fromCharCode(...header.subarray(0, 3)) !== "ID3") return 0;
+
+    const sizeBytes = header.subarray(6, 10);
+    if ([...sizeBytes].some((byte) => (byte & 0x80) !== 0)) return null;
+
+    return 10 + ((sizeBytes[0] << 21) | (sizeBytes[1] << 14) | (sizeBytes[2] << 7) | sizeBytes[3]);
+}
+
+export async function isMp3File(filePath: string): Promise<boolean> {
+    const file = await fs.open(filePath, "r");
+
+    try {
+        const stats = await file.stat();
+        if (stats.size < 8) return false;
+
+        const header = new Uint8Array(Math.min(12, stats.size));
+        await file.read(header, 0, header.length, 0);
+        const audioOffset = getId3AudioOffset(header);
+        if (audioOffset === null || audioOffset >= stats.size) return false;
+
+        const scan = new Uint8Array(Math.min(MP3_SCAN_BYTES, stats.size - audioOffset));
+        await file.read(scan, 0, scan.length, audioOffset);
+        return hasMp3FrameSequence(scan);
+    } finally {
+        await file.close();
+    }
+}
+
 export function selectAudioImportFile(candidates: AudioImportCandidate[]): string {
-    const mp3Files = candidates.filter((candidate) => path.extname(candidate.name).toLowerCase() === ".mp3");
+    const mp3Files = candidates.filter((candidate) => path.extname(candidate.name).toLowerCase() === ".mp3" && candidate.isValidMp3);
     if (mp3Files.length > 0) {
         return mp3Files.reduce((largest, candidate) => (candidate.size > largest.size ? candidate : largest)).name;
     }
 
-    if (candidates.some((candidate) => [".ogg", ".wav"].includes(path.extname(candidate.name).toLowerCase()))) {
+    if (candidates.some((candidate) => [".mp3", ".ogg", ".wav"].includes(path.extname(candidate.name).toLowerCase()))) {
         throw new UnsupportedAudioFormatError();
     }
 

--- a/src/lib/media-format.test.ts
+++ b/src/lib/media-format.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { GameMode } from "@/actions/types";
+import { getMediaMimeType, MediaUnavailableError } from "./media-format";
+
+describe("media format validation", () => {
+    test("maps actual extensions to MIME types and rejects incompatible media", () => {
+        expect(getMediaMimeType(GameMode.Background, "123.webp")).toBe("image/webp");
+        expect(getMediaMimeType(GameMode.Skin, "skin.png")).toBe("image/png");
+        expect(getMediaMimeType(GameMode.Audio, "song.mp3")).toBe("audio/mpeg");
+        expect(() => getMediaMimeType(GameMode.Background, "song.mp3")).toThrow(MediaUnavailableError);
+    });
+});

--- a/src/lib/media-format.ts
+++ b/src/lib/media-format.ts
@@ -1,0 +1,34 @@
+import path from "path";
+import { GameMode } from "@/actions/types";
+
+const MIME_TYPES: Record<string, string> = {
+    ".webp": "image/webp",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".mp3": "audio/mpeg",
+    ".ogg": "audio/ogg",
+    ".wav": "audio/wav",
+};
+
+const MODE_EXTENSIONS: Record<GameMode, Set<string>> = {
+    [GameMode.Background]: new Set([".webp", ".jpg", ".jpeg", ".png"]),
+    [GameMode.Audio]: new Set([".mp3", ".ogg", ".wav"]),
+    [GameMode.Skin]: new Set([".webp", ".jpg", ".jpeg", ".png"]),
+};
+
+export class MediaUnavailableError extends Error {
+    constructor() {
+        super("The selected media file is unavailable or invalid.");
+        this.name = "MediaUnavailableError";
+    }
+}
+
+export function getMediaMimeType(gameMode: GameMode, filename: string): string {
+    const extension = path.extname(filename).toLowerCase();
+    if (!MODE_EXTENSIONS[gameMode]?.has(extension) || !MIME_TYPES[extension]) {
+        throw new MediaUnavailableError();
+    }
+
+    return MIME_TYPES[extension];
+}

--- a/src/lib/skin-import.ts
+++ b/src/lib/skin-import.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+const screenshotSchema = z.object({
+    category: z.number().int().nonnegative(),
+    gamemode: z.number().int().nonnegative(),
+    large: z.string().url(),
+    medium: z.string().url(),
+    small: z.string().url(),
+});
+
+const skinDataSchema = z.object({
+    _nsfw: z.boolean(),
+    id: z.number().int().positive(),
+    name: z.string().trim().min(1),
+    gamemodes: z.array(z.number().int().nonnegative()),
+    screenshots: z.array(screenshotSchema).min(1),
+    link_to_skin: z.string().url(),
+});
+
+const skinApiResponseSchema = z.discriminatedUnion("status", [
+    z.object({ status: z.literal("success"), message: skinDataSchema }),
+    z.object({ status: z.literal("failed"), message: z.enum(["rate limited", "no api key", "invalid api key"]) }),
+]);
+
+export type SkinImportData = z.infer<typeof skinDataSchema>;
+
+export function parseSkinApiResponse(input: unknown, requestedSkinId: number): SkinImportData {
+    const response = skinApiResponseSchema.parse(input);
+
+    if (response.status === "failed") {
+        throw new Error(`Skin API error: ${response.message}`);
+    }
+
+    if (response.message.id !== requestedSkinId) {
+        throw new Error("Skin API returned an unexpected skin ID.");
+    }
+
+    if (response.message._nsfw) {
+        throw new Error("NSFW skins are not allowed.");
+    }
+
+    return response.message;
+}


### PR DESCRIPTION
Importer and game-media paths reject mislabeled or unusable assets while keeping the existing storage and delivery architecture intact.

- validates MP3 content by locating consecutive MPEG Layer III frames after any ID3 tag instead of trusting the file extension
- rejects renamed OGG/WAV payloads and unsupported audio with a controlled admin-facing result; no transcoding is added
- selects the largest content-validated MP3 candidate
- validates external skin metadata with Zod, rejects NSFW skins, initializes bulk-import directories, and converts screenshots to actual WebP with Sharp
- derives data-URL MIME types from saved extensions, including WebP backgrounds, and rejects incompatible formats
- excludes records with missing media filenames and turns read failures into controlled errors
- distinguishes exhausted death-mode content from operational media failures
- preserves the complete audio timeout, error, playback-failure, retry, spinner, and cleanup behavior merged through PR #35

**Tests**

- `bun install --frozen-lockfile` — passed, no lockfile changes
- `bun run check` — passed
- `bun test` — passed (61 tests)
- `bun run build` — passed

The audio-format tests use temporary representative files: an ID3-tagged two-frame MP3 passes, while OGG and WAV data renamed with `.mp3` fail.

**Conflict resolution**

`GameAudio.tsx` retains current `main` byte-for-byte except that the hard-coded `audio/mp3` source hint is removed so the data URL’s actual MIME type is authoritative.

**Remaining limitations**

- OGG and WAV mapsets are rejected rather than transcoded.
- The conservative detector rejects free-format, single-frame, and truncated MP3 files; normal CBR/VBR MPEG Layer III files are supported.
- Existing legacy files previously saved under an incorrect extension are not repaired because that requires a separate data-repair workflow.
- No schema migration, transactional import redesign, media endpoint, caching, clipping, or session-lock change is included.