### PR TITLE
chore: standardize AGPL-3.0-only licensing

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,17 @@
+# Licensing and branding
+
+Copyright © 2026 Muhammed Fatih and hanami-osu contributors.
+
+The collective work in this repository is distributed under the GNU Affero General Public License version 3 only (`AGPL-3.0-only`). See [`LICENSE`](./LICENSE).
+
+Unless explicitly stated otherwise, contributions are accepted under `AGPL-3.0-only`.
+
+## Third-party material
+
+Dependencies, assets, fonts, icons, osu! material, beatmap content, skin screenshots, audio, and other externally sourced material retain their respective licenses and are not relicensed by this repository. Their notices and license terms take precedence for that material.
+
+## Names and branding
+
+The code license does not grant rights to the hanami-osu name, osu!guessr name, logos, or visual identity. No permission is granted to use those marks in a way that suggests official affiliation, endorsement, or origin. Forks should use distinct names and branding.
+
+osu!guessr is an independent community project and is not affiliated with or endorsed by osu! or ppy Pty Ltd.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ bun run build
 
 ## License
 
-This project is licensed under the GNU Affero General Public License v3.0. See [LICENSE](LICENSE).
+Copyright © 2026 Muhammed Fatih and hanami-osu contributors.
+
+This project is licensed under the GNU Affero General Public License version 3 only (`AGPL-3.0-only`). See [LICENSE](./LICENSE) and [LICENSING.md](./LICENSING.md) for the full terms, third-party material, contribution licensing, and branding policy.
 
 ## Contact
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "osu-guessr",
     "version": "0.1.0",
     "private": true,
+    "license": "AGPL-3.0-only",
     "scripts": {
         "dev": "dotenv -e .env -- next dev",
         "build": "prisma generate && IS_DOCKER_BUILD=true next build",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,7 +26,7 @@ export default function Footer() {
                     ))}
                 </p>
                 <AdSlot />
-                <div className="mt-2 sm:mt-3 text-xs sm:text-sm text-foreground/50 flex justify-center gap-4">
+                <div className="mt-2 sm:mt-3 text-xs sm:text-sm text-foreground/50 flex flex-wrap justify-center gap-4">
                     <Link href="/about" className="hover:text-foreground transition-colors duration-200">
                         {t.components.footer.about}
                     </Link>
@@ -36,6 +36,22 @@ export default function Footer() {
                     <Link href="/tos" className="hover:text-foreground transition-colors duration-200">
                         {t.components.footer.tos}
                     </Link>
+                    <a
+                        href="https://github.com/hanami-osu/osu-guessr"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-foreground transition-colors duration-200"
+                    >
+                        Source
+                    </a>
+                    <a
+                        href="https://github.com/hanami-osu/osu-guessr/blob/main/LICENSE"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-foreground transition-colors duration-200"
+                    >
+                        AGPL-3.0
+                    </a>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
## Summary

- explicitly declare `AGPL-3.0-only` in package metadata and the README
- add copyright, contribution, third-party material, and branding guidance in `LICENSING.md`
- add direct source-code and AGPL links to the public footer

## Note

The repository already used the GNU AGPLv3 license text. This PR makes the `-only` choice and the hanami-osu licensing policy explicit and consistent with the other projects.

## Verification

Documentation, metadata, and footer links only. No application behavior or data handling changed.